### PR TITLE
DO NOT MERGE: use parseconfig to read awscred

### DIFF
--- a/lib/vagrant-openshift/action/generate_template.rb
+++ b/lib/vagrant-openshift/action/generate_template.rb
@@ -14,7 +14,6 @@
 # limitations under the License.
 #++
 require 'yaml'
-require 'parseconfig'
 require 'fog'
 
 module Vagrant
@@ -56,6 +55,7 @@ module Vagrant
           return if box_info[:aws][:ami_tag_prefix].nil?
           @env[:ui].info("Reading AWS credentials form #{@aws_creds_file.to_s}")
           if @aws_creds_file.exist?
+            aws_creds = Hash[File.open(@aws_creds_file).readlines.map {|l| l.strip }.select {|l| not '' == l and not l.start_with? '#' and not l.start_with? '['}.map {|l| l.split '=' }]
             aws_creds = ParseConfig.new(@aws_creds_file)
             fog_config = {
                 :provider              => :aws,

--- a/lib/vagrant-openshift/action/generate_template.rb
+++ b/lib/vagrant-openshift/action/generate_template.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 #++
 require 'yaml'
+require 'parseconfig'
 require 'fog'
 
 module Vagrant
@@ -55,8 +56,7 @@ module Vagrant
           return if box_info[:aws][:ami_tag_prefix].nil?
           @env[:ui].info("Reading AWS credentials form #{@aws_creds_file.to_s}")
           if @aws_creds_file.exist?
-            aws_creds = @aws_creds_file.exist? ? Hash[*(File.open(@aws_creds_file.to_s).readlines.map{ |l| l.split('=') }.flatten.map{ |i| i.strip })] : {}
-
+            aws_creds = ParseConfig.new(@aws_creds_file)
             fog_config = {
                 :provider              => :aws,
                 :region                => box_info[:aws][:ami_region],

--- a/lib/vagrant-openshift/templates/command/init-openshift/Vagrantfile.erb
+++ b/lib/vagrant-openshift/templates/command/init-openshift/Vagrantfile.erb
@@ -44,7 +44,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # https://github.com/mitchellh/vagrant-aws
 
     aws_creds_file = Pathname.new(File.expand_path("<%= box_info[:aws_creds_file]%>"))
-    aws_creds = aws_creds_file.exist? ? Hash[*(File.open(aws_creds_file.to_s).readlines.map{ |l| l.split('=') }.flatten.map{ |i| i.strip })] : {}
+    aws_creds = aws_creds_file.exist? ? Hash[*(File.open('.awscred_complete').readlines.map {|l| l.strip }.select {|l| not '' == l and not l.start_with? '#' and not l.start_with? '['}.map {|l| l.split '=' })] : {}
 
     aws.access_key_id    = aws_creds["AWSAccessKeyId"] || "AWS ACCESS KEY"
     aws.secret_access_key = aws_creds["AWSSecretKey"] || "AWS SECRET KEY"


### PR DESCRIPTION
Use rubygem parseconfig to read the .awscred file
This allows for all standard INI formatting including nesting, sections and comments.

Note: while the lib can use parseconfig, apparently Vagrantfile cannot, so the parsing issues with .awscred remain.

Thinking about how to resolve.