### PR TITLE
Force line endings to be LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* autocrlf=input eol=lf


### PR DESCRIPTION
We need to force the line endings to be linux like so that the vagrant plugin works in a Windows dev environment.
