### PR TITLE
Optimize clone checkout

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -58,9 +58,9 @@ module Vagrant
           b.use CreateYumRepositories
           b.use YumUpdate
           b.use Clean
-          b.use CloneUpstreamRepositories
+          #b.use CloneUpstreamRepositories
           b.use SetHostName
-          b.use CheckoutRepositories
+          #b.use CheckoutRepositories
           b.use InstallGeard
           #b.use BuildGeard
         end
@@ -75,8 +75,8 @@ module Vagrant
       def self.build_geard_broker(options)
         Vagrant::Action::Builder.new.tap do |b|
           b.use Clean
-          b.use CloneUpstreamRepositories
-          b.use CheckoutRepositories, options
+          #b.use CloneUpstreamRepositories
+          #b.use CheckoutRepositories, options
           b.use BuildGeardBroker
         end
       end
@@ -160,6 +160,18 @@ module Vagrant
           b.use ConfigValidate
           b.use VagrantPlugins::AWS::Action::ConnectAWS
           b.use ModifyInstance, options
+        end
+      end
+
+      def self.clone_upstream_repositories(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use CloneUpstreamRepositories, options
+        end
+      end
+
+      def self.checkout_repositories(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use CheckoutRepositories, options
         end
       end
 

--- a/lib/vagrant-openshift/action/clone_upstream_repositories.rb
+++ b/lib/vagrant-openshift/action/clone_upstream_repositories.rb
@@ -20,9 +20,10 @@ module Vagrant
       class CloneUpstreamRepositories
         include CommandHelper
 
-        def initialize(app, env)
+        def initialize(app, env, options)
           @app = app
           @env = env
+          @options = options
         end
 
         def call(env)
@@ -36,6 +37,10 @@ module Vagrant
           Constants.repos.each do |repo_name, url|
             bare_repo_name = repo_name + "-bare"
             bare_repo_path = Constants.build_dir + bare_repo_name
+
+            if @options[:clean]
+              git_clone_commands += "rm -fr #{bare_repo_path};\n"
+            end
 
             git_clone_commands += "if [ ! -d #{bare_repo_path} ]; then\n"
             git_clone_commands += "git clone --bare #{url} #{bare_repo_path};\n"

--- a/lib/vagrant-openshift/command/checkout_repositories.rb
+++ b/lib/vagrant-openshift/command/checkout_repositories.rb
@@ -1,0 +1,54 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require_relative "../action"
+
+module Vagrant
+  module Openshift
+    module Commands
+      class CheckoutRepositories < Vagrant.plugin(2, :command)
+        include CommandHelper
+
+        def self.synopsis
+          "checkout specified branch from cloned upstream repository"
+        end
+
+        def execute
+          options = {}
+
+          opts = OptionParser.new do |o|
+            o.banner = "Usage: vagrant checkout-repos"
+            o.separator ""
+            
+            o.on("-b [branch_name]", "--branch [branch_name]", String, "Check out the specified branch. Default is 'master'.") do |f|
+              options[:branch] = {"origin-server" => f}
+            end
+                        
+           #@options[:branch][repo_name]            
+          end
+
+          # Parse the options
+          argv = parse_options(opts)
+
+          with_target_vms(argv, :reverse => true) do |machine|
+            actions = Vagrant::Openshift::Action.checkout_repositories(options)
+            @env.action_runner.run actions, {:machine => machine}
+            0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/command/clone_upstream_repositories.rb
+++ b/lib/vagrant-openshift/command/clone_upstream_repositories.rb
@@ -1,0 +1,53 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require_relative "../action"
+
+module Vagrant
+  module Openshift
+    module Commands
+      class CloneUpstreamRepositories < Vagrant.plugin(2, :command)
+        include CommandHelper
+
+        def self.synopsis
+          "clones upstream repositories into vm"
+        end
+
+        def execute
+          options = {}
+          options[:clean] = false
+
+          opts = OptionParser.new do |o|
+            o.banner = "Usage: vagrant clone-upstream-repositories"
+            o.separator ""
+
+            o.on("-c", "--clean", "Remove the current bare repositories on disk if present") do |c|
+              options[:clean] = true
+            end
+          end
+
+          # Parse the options
+          argv = parse_options(opts)
+
+          with_target_vms(argv, :reverse => true) do |machine|
+            actions = Vagrant::Openshift::Action.clone_upstream_repositories(options)
+            @env.action_runner.run actions, {:machine => machine}
+            0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/plugin.rb
+++ b/lib/vagrant-openshift/plugin.rb
@@ -92,6 +92,16 @@ module Vagrant
         Commands::ModifyInstance
       end
 
+      command "clone-upstream-repos" do
+        require_relative "command/clone_upstream_repositories"
+        Commands::CloneUpstreamRepositories
+      end
+
+      command "checkout-repos" do
+        require_relative "command/checkout_repositories"
+        Commands::CheckoutRepositories
+      end
+      
       provisioner(:openshift) do
         require_relative "provisioner"
         Provisioner


### PR DESCRIPTION
Break out clone and checkout repositories into their own commands.
Modified existing install-geard, build-geard, build-geard-broker commands to no longer perform clone and checkout.

Jenkins job should be updated as follows:
...
vagrant up --provider aws
vagrant clone-upstream-repos --clean
vagrant checkout-repos --branch next_gen_node
vagrant install-geard
vagrant build-geard
vagrant build-geard-broker
...
