### PR TITLE
Do serial docker pull to fix docker pull issue

### DIFF
--- a/lib/vagrant-openshift/action/install_geard_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_geard_base_dependencies.rb
@@ -30,12 +30,8 @@ module Vagrant
           sudo(env[:machine], %{
 systemctl enable docker
 systemctl start docker
-docker pull openshift/centos-mongodb >/dev/null &
-pid1=$!
-docker pull openshift/centos-ruby >/dev/null &
-pid2=$!
-wait $pid1
-wait $pid2
+docker pull openshift/centos-mongodb
+docker pull openshift/centos-ruby
 touch #{Vagrant::Openshift::Constants.deps_marker}
           })
           #is_fedora = env[:machine].communicate.test("test -e /etc/fedora-release")


### PR DESCRIPTION
Doing a background docker pull was causing docker to not pull 2 layers that were shared by both images intermittently.  Moving to a serial pull in base_ami now to avoid issue and increase stability.
