### PR TITLE
Increase timeout for broker build

### DIFF
--- a/lib/vagrant-openshift/action/build_geard_broker.rb
+++ b/lib/vagrant-openshift/action/build_geard_broker.rb
@@ -33,7 +33,7 @@ pushd broker/docker/origin-broker-builder
   docker build --rm -t origin-broker-builder .
 popd
 gear build /data/src/github.com/openshift/origin-server/ origin-broker-builder origin-broker
-          }))
+          }), {:timeout => 60*20})
           @app.call(env)
         end
       end


### PR DESCRIPTION
Timeout occurred while running ssh/sudo command: 
pushd /data/src/github.com/openshift/origin-server
  commit_id=`git rev-parse master`
  mkdir -p /data/.sync/
  if [ -f /data/.sync/origin-server ]
  then
    previous_commit_id=$(cat /data/.sync/origin-server)
  fi
  if [ "$previous_commit_id" != "$commit_id" ]
  then

echo "Performing broker build..."
set -e
pushd broker/docker/origin-broker-builder
  docker build --rm -t origin-broker-builder .
popd
gear build /data/src/github.com/openshift/origin-server/ origin-broker-builder origin-broker

  else
    echo "No update for origin-server"
  fi
  echo -n $commit_id > /data/.sync/origin-server
popd

Build step 'Execute shell' marked build as failure
