### PR TITLE
Do not clean bare repos in geard environment

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -42,7 +42,6 @@ module Vagrant
           b.use CreateYumRepositories
           b.use YumUpdate
           b.use InstallGeardBaseDependencies
-          b.use Clean
           b.use SetHostName
           #b.use SetupBindDnsKey
           #b.use CreatePuppetFile
@@ -53,7 +52,6 @@ module Vagrant
         Vagrant::Action::Builder.new.tap do |b|
           b.use CreateYumRepositories
           b.use YumUpdate
-          b.use Clean
           b.use SetHostName
           b.use InstallGeard
           b.use BuildGeard
@@ -86,9 +84,6 @@ module Vagrant
 
       def self.build_geard_broker(options)
         Vagrant::Action::Builder.new.tap do |b|
-          b.use Clean
-          #b.use CloneUpstreamRepositories
-          #b.use CheckoutRepositories, options
           b.use BuildGeardBroker
         end
       end
@@ -125,6 +120,10 @@ module Vagrant
       def self.repo_sync_geard(options)
         Vagrant::Action::Builder.new.tap do |b|
           b.use PrepareSshConfig
+          if options[:clean]
+            b.use Clean
+            b.use CloneUpstreamRepositories
+          end
           b.use SyncLocalRepository
           b.use CheckoutRepositories
           unless options[:no_build]

--- a/lib/vagrant-openshift/command/repo_sync_geard.rb
+++ b/lib/vagrant-openshift/command/repo_sync_geard.rb
@@ -28,10 +28,15 @@ module Vagrant
         def execute
           options = {}
           options[:no_build] = false
+          options[:clean] = false
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant sync-geard [vm-name]"
             o.separator ""
+
+            o.on("-c", "--clean", "Delete existing repo before syncing") do |f|
+              options[:clean] = f
+            end
 
             o.on("--dont-install", "Don't build and install updated source") do |f|
               options[:no_build] = true


### PR DESCRIPTION
The following actions resulted in our bare repos being deleted.
1) build-geard-base
2) install-geard
3) build-geard-broker

This ruined the following sequence:

$ vagrant up
<change code>
$ vagrant sync-geard
<change code>
$ vagrant sync-geard [FAIL! BARE REPOS WERE DESTROYED]
