### PR TITLE
Filter support for sync-geard

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -135,12 +135,12 @@ module Vagrant
             b.use CheckoutRepositories
           end
           unless options[:no_build]
-            b.use BuildGeard
-            b.use RestartGeard
-            b.use BuildGeardImages
-            b.use BuildGeardBroker
-            b.use RestartGeardBroker
-            b.use InstallRhc
+            b.use BuildGeard if options[:include].include? Vagrant::Openshift::Constants::FILTER_GEARD
+            b.use RestartGeard if options[:include].include? Vagrant::Openshift::Constants::FILTER_GEARD
+            b.use BuildGeardImages if options[:include].include? Vagrant::Openshift::Constants::FILTER_IMAGES
+            b.use BuildGeardBroker if options[:include].include? Vagrant::Openshift::Constants::FILTER_BROKER
+            b.use RestartGeardBroker if options[:include].include? Vagrant::Openshift::Constants::FILTER_BROKER
+            b.use InstallRhc if options[:include].include? Vagrant::Openshift::Constants::FILTER_RHC
           end
         end
       end

--- a/lib/vagrant-openshift/command/repo_sync_geard.rb
+++ b/lib/vagrant-openshift/command/repo_sync_geard.rb
@@ -30,6 +30,7 @@ module Vagrant
           options[:no_build] = false
           options[:clean] = false
           options[:source] = false
+          options[:include] = [ Vagrant::Openshift::Constants::FILTER_BROKER , Vagrant::Openshift::Constants::FILTER_GEARD, Vagrant::Openshift::Constants::FILTER_IMAGES, Vagrant::Openshift::Constants::FILTER_RHC]
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant sync-geard [vm-name]"
@@ -50,6 +51,11 @@ module Vagrant
             o.on("-h", "--help", "Show this message") do |f|
               options[:help] = f
             end
+
+            o.on("-i [comp comp]", "--include", String, "Sync specified components.  Default: #{options[:include].join " "}") do |f|
+              options[:include] = f.split " "
+            end
+
           end
 
           # Parse the options

--- a/lib/vagrant-openshift/constants.rb
+++ b/lib/vagrant-openshift/constants.rb
@@ -18,6 +18,12 @@ require 'pathname'
 module Vagrant
   module Openshift
     class Constants
+      
+      FILTER_BROKER="broker"
+      FILTER_IMAGES="images"
+      FILTER_RHC="rhc"
+      FILTER_GEARD="geard"
+
       def self.repos
         {
           'origin-server' => 'https://github.com/openshift/origin-server.git',


### PR DESCRIPTION
vagrant sync-geard --include broker

just does operations for broker, with a Gemfile.lock, was able to get iterative cycle on local vm reduced further for broker dev to < 1 min.

vagrant sync-geard --include "geard broker"

does both

vagrant sync-geard

does all as always.
