### PR TITLE
Install rhc in vagrant user gem env

### DIFF
--- a/lib/vagrant-openshift/action/install_rhc.rb
+++ b/lib/vagrant-openshift/action/install_rhc.rb
@@ -26,11 +26,11 @@ module Vagrant
         end
 
         def call(env)
-          sudo(env[:machine], sync_bash_command('rhc', %{
+          do_execute(env[:machine], sync_bash_command('rhc', %{
 echo "Build and install rhc from local source"
+gem uninstall rhc -x -q
 rm -f rhc-*.gem
 gem build rhc.gemspec
-gem uninstall rhc -x
 gem install $(find ./ -name 'rhc-*.gem')
 rm -f rhc-*.gem
           }))

--- a/lib/vagrant-openshift/constants.rb
+++ b/lib/vagrant-openshift/constants.rb
@@ -52,7 +52,7 @@ module Vagrant
       end
 
       def self.sync_dir
-        Pathname.new "/vagrant-sync"
+        Pathname.new "~/sync"
       end
 
       def self.build_dir


### PR DESCRIPTION
This change required us to root the 'sync' location in /home/vagrant/sync path so we can do a sync_bash_command operation with either the root or vagrant user.
