### PR TITLE
Added 'destroy-instance' command to mark AWS instance for termination

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -209,6 +209,14 @@ module Vagrant
         end
       end
 
+      def self.destroy_instance(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use VagrantPlugins::AWS::Action::ConnectAWS
+          b.use DestroyInstance
+        end
+      end
+
       def self.modify_ami(options)
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate
@@ -279,6 +287,7 @@ module Vagrant
       autoload :GenerateTemplate, action_root.join("generate_template")
       autoload :CreateAMI, action_root.join("create_ami")
       autoload :ModifyInstance, action_root.join("modify_instance")
+      autoload :DestroyInstance, action_root.join("destroy_instance")
       autoload :ModifyAMI, action_root.join("modify_ami")
       autoload :DownloadArtifacts, action_root.join("download_artifacts")
       autoload :TestExitCode, action_root.join("test_exit_code")

--- a/lib/vagrant-openshift/action/destroy_instance.rb
+++ b/lib/vagrant-openshift/action/destroy_instance.rb
@@ -1,0 +1,64 @@
+#--
+# Copyright 2014 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require 'xmlsimple'
+
+module Vagrant
+  module Openshift
+    module Action
+      class DestroyInstance
+        include CommandHelper
+
+        def initialize(app, env)
+          @app = app
+          @env = env
+        end
+
+        def cleanup_vagrant_machine(machine_name)
+          FileUtils.rm_rf(
+            File.join('.vagrant', 'machines', machine_name.to_s, 'aws'),
+            :verbose => true
+          )
+        end
+
+        def call(env)
+          unless env[:machine].state.id == :running
+            raise VagrantPlugins::AWS::Errors::FogError,
+              :message => "Error: EC2 Machine is not available"
+          end
+
+          begin
+            machine = env[:aws_compute].servers.get(env[:machine].id)
+            machine_name = machine.tags["Name"]
+            env[:aws_compute].tags.create(
+              :resource_id => machine.identity,
+              :key => 'Name',
+              :value => "#{machine_name}-terminate"
+            )
+            env[:machine].ui.info("Instance #{machine_name} successfully marked for termination.")
+            env[:machine].ui.info("Destroying #{machine_name}")
+            cleanup_vagrant_machine(env[:machine].name)
+          rescue Excon::Errors::BadRequest => e
+            doc = XMLSimple.xml_in(e.response.body)
+            code = doc['Response']['Errors']['Error']['Code'][0]
+            message = doc['Response']['Errors']['Error']['Message'][0]
+            raise VagrantPlugins::AWS::Errors::FogError, :message => "#{message}. Code: #{code}"
+          end
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/command/destroy_instance.rb
+++ b/lib/vagrant-openshift/command/destroy_instance.rb
@@ -1,0 +1,54 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require_relative "../action"
+
+module Vagrant
+  module Openshift
+    module Commands
+      class DestroyInstance < Vagrant.plugin(2, :command)
+        include CommandHelper
+
+        def self.synopsis
+          "mark the current devenv instance for termination"
+        end
+
+        def execute
+          options = {}
+
+          opts = OptionParser.new do |o|
+            o.banner = "Usage: vagrant destroy-instance"
+            o.separator ""
+
+            o.on("-h", "--help", "Show this message") do |f|
+              options[:help] = true
+            end
+          end
+
+          if options[:help]
+            @env.ui.info opts
+            exit
+          end
+
+          with_target_vms(parse_options(opts), :reverse => true) do |machine|
+            actions = Vagrant::Openshift::Action.destroy_instance(options)
+            @env.action_runner.run actions, {:machine => machine}
+            0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/plugin.rb
+++ b/lib/vagrant-openshift/plugin.rb
@@ -127,6 +127,11 @@ module Vagrant
         Commands::ModifyInstance
       end
 
+      command "destroy-instance" do
+        require_relative "command/destroy_instance"
+        Commands::DestroyInstance
+      end
+
       command "clone-upstream-repos" do
         require_relative "command/clone_upstream_repositories"
         Commands::CloneUpstreamRepositories


### PR DESCRIPTION
Currently, you can use `modify-instance` to mark the Amazon instance for termination (rename to instance-terminate).
However, this will not remove the Vagrant machine under `.vagrant/machines/default/aws` directory. So if you do the `vagrant up` afterward, then Vagrant will try to re-use the instance that is marked for termination instead of launching a new AWS instance.

This PR will add `destroy-instance` command to Vagrant, that will:
- Rename the AWS instance associated with the current Vagrant machine to `NAME-terminate`
- Cleanup the `.vagrant/machines/default/aws` folder so the `vagrant up` will spawn a new machine
