### PR TITLE
Added 'unf' gem into gemspec to get rid of fog warning

### DIFF
--- a/vagrant-openshift.gemspec
+++ b/vagrant-openshift.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("thor")
   gem.add_dependency("pry")
   gem.add_dependency("fog")
+  gem.add_dependency("unf")
   gem.add_dependency("xml-simple")
   gem.add_dependency("vagrant-aws")
 end


### PR DESCRIPTION
This will remove:

```
 ~/code/rh/openshift → vagrant up --provider=aws
Bringing machine 'default' up with 'aws' provider...
[fog][WARNING] Unable to load the 'unf' gem. Your AWS strings may not be properly encoded.

```
