### PR TITLE
Gear daemon requires docker to be started to run

### DIFF
--- a/lib/vagrant-openshift/action/install_geard.rb
+++ b/lib/vagrant-openshift/action/install_geard.rb
@@ -50,6 +50,8 @@ GEARD_OPTS=http://172.17.42.1:43273
 cat > /usr/lib/systemd/system/geard.service <<DELIM
 [Unit]
 Description=Gear Provisioning Daemon (geard)
+After=docker.service
+Requires=docker.service
 Documentation=https://github.com/openshift/geard
 
 [Service]


### PR DESCRIPTION
This fixes up start-up order sequence since gear requires docker running in order to listen on the docker gateway to support communication between container and host.
