### PR TITLE
Run gear daemon from /usr/bin so it can startup in local vagrant on boot

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -56,6 +56,7 @@ module Vagrant
           b.use SetHostName
           b.use InstallGeard
           b.use BuildGeard
+          b.use RestartGeard
         end
       end
 

--- a/lib/vagrant-openshift/action/install_geard.rb
+++ b/lib/vagrant-openshift/action/install_geard.rb
@@ -57,7 +57,7 @@ Documentation=https://github.com/openshift/geard
 [Service]
 Type=simple
 EnvironmentFile=-/etc/default/gear
-ExecStart=/data/bin/gear daemon $GEARD_OPTS
+ExecStart=/usr/bin/gear daemon $GEARD_OPTS
 
 [Install]
 WantedBy=multi-user.target
@@ -65,7 +65,6 @@ DELIM
 
 systemctl restart sshd
 systemctl enable geard.service
-systemctl start geard
           })
 
           @app.call(env)


### PR DESCRIPTION
When doing local vagrant dev, the gear daemon was not starting on boot even though it was enabled.
After further debug, it was realized that we cannot have a service that starts on boot that is located in a local synced_folder from vagrant.
The gear contrib/build command moves binaries into /usr/bin so we will use that instead in our service file.
This fixes the issue now with geard not running across restarts in local vagrant env.
