### PR TITLE
Docker defaults DNS to 8.8.8.8 if resolv.conf uses 127.0.0.1

### DIFF
--- a/lib/vagrant-openshift/action/setup_bind_host.rb
+++ b/lib/vagrant-openshift/action/setup_bind_host.rb
@@ -103,8 +103,8 @@ include "/etc/named.root.key";
 include "/var/named/#{domain}.zones";
 include "#{domain}.key";
 EOF
-if ! cat /etc/dhcp/dhclient.conf | grep 'prepend domain-name-servers 127.0.0.1;' 2>&1 > /dev/null ; then
-  echo "$(cat /etc/dhcp/dhclient.conf)\nprepend domain-name-servers 127.0.0.1;" > /etc/dhcp/dhclient.conf;
+if ! cat /etc/dhcp/dhclient.conf | grep 'prepend domain-name-servers 172.17.42.1;' 2>&1 > /dev/null ; then
+  echo "$(cat /etc/dhcp/dhclient.conf)\nprepend domain-name-servers 172.17.42.1;" > /etc/dhcp/dhclient.conf;
 fi
 systemctl enable named
 systemctl restart named


### PR DESCRIPTION
If the resolv.conf file uses 127.0.0.1 as first nameserver, then docker will use 8.8.8.8 as nameserver of each container.  This causes problems when certain networks block 8.8.8.8 tcp traffic which then makes docker builds not function in local vagrant environments.  To work-around this, the nameserver is also listening on the docker0 address, so we will use that instead in our network configuration.  In this way, docker containers are also able to lookup address in our dynamic dns.
