### PR TITLE
Ignore failed AMIs when searching ami_tag_prefix

### DIFF
--- a/lib/vagrant-openshift/action/generate_template.rb
+++ b/lib/vagrant-openshift/action/generate_template.rb
@@ -77,7 +77,8 @@ module Vagrant
 
             aws_compute = Fog::Compute.new(fog_config)
             @env[:ui].info("Searching for latest base AMI")
-            images = aws_compute.images.all({'Owner' => 'self', 'name' => "#{box_info[:aws][:ami_tag_prefix]}*" })
+            images = aws_compute.images.all({'Owner' => 'self', 'name' => "#{box_info[:aws][:ami_tag_prefix]}*",
+                                             'state' => 'available' })
             latest_image = images.sort_by{ |i| i.name.split("_")[-1].to_i }.last
             box_info[:aws][:ami] = latest_image.id
             @env[:ui].info("Found: #{latest_image.id} (#{latest_image.name})")


### PR DESCRIPTION
Previously an AMI with a state of failed would be used if it was the highest numbered AMI with the tag_prefix.
