### PR TITLE
Change how OpenShift 3 builds are done

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ test/origin-server
 test/puppet-openshift_origin
 test/rhc
 tmp
+vendor

--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -41,9 +41,9 @@ module Vagrant
         Vagrant::Action::Builder.new.tap do |b|
           b.use CreateYumRepositories
           b.use YumUpdate
-          b.use InstallOpenshift3BaseDependencies
-          b.use InstallOpenshift3Images
           b.use SetHostName
+          b.use InstallOpenshift3BaseDependencies
+          b.use BuildOpenshift3BaseImages
         end
       end
 
@@ -53,13 +53,12 @@ module Vagrant
           b.use YumUpdate
           b.use SetHostName
           b.use InstallOpenshift3
-          b.use BuildOpenshift3
         end
       end
 
       def self.build_openshift3(options)
         Vagrant::Action::Builder.new.tap do |b|
-          b.use BuildOpenshift3
+          b.use BuildOpenshift3, options
         end
       end
 
@@ -69,15 +68,9 @@ module Vagrant
         end
       end
 
-      def self.build_openshift3_images(options)
+      def self.build_openshift3_base_images(options)
         Vagrant::Action::Builder.new.tap do |b|
-          b.use BuildOpenshift3Images, options
-        end
-      end
-
-      def self.build_openshift3_infrastructure_images(options)
-        Vagrant::Action::Builder.new.tap do |b|
-          b.use BuildOpenshift3InfrastructureImages, options
+          b.use BuildOpenshift3BaseImages, options
         end
       end
 
@@ -122,9 +115,9 @@ module Vagrant
             b.use CheckoutRepositories
           end
           unless options[:no_build]
-            b.use BuildOpenshift3 if options[:include].include? Vagrant::Openshift::Constants::FILTER_ORIGIN
-            b.use TryRestartOpenshift3 if options[:include].include? Vagrant::Openshift::Constants::FILTER_ORIGIN
-            b.use BuildOpenshift3Images, options if options[:include].include? Vagrant::Openshift::Constants::FILTER_IMAGES
+            b.use(BuildOpenshift3BaseImages, options) if options[:images] && options[:include].include?(Vagrant::Openshift::Constants::FILTER_ORIGIN)
+            b.use(BuildOpenshift3, options) if options[:include].include? Vagrant::Openshift::Constants::FILTER_ORIGIN
+            b.use(TryRestartOpenshift3) if options[:include].include? Vagrant::Openshift::Constants::FILTER_ORIGIN
           end
         end
       end
@@ -200,6 +193,12 @@ module Vagrant
         end
       end
 
+      def self.push_openshift3_release(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use PushOpenshift3Release, options
+        end
+      end
+
       def self.clone_upstream_repositories(options)
         Vagrant::Action::Builder.new.tap do |b|
           b.use CloneUpstreamRepositories, options
@@ -231,10 +230,9 @@ module Vagrant
       autoload :YumUpdate, action_root.join("yum_update")
       autoload :SetupBuilderFiles, action_root.join("setup_builder_files")
       autoload :InstallOpenshift2BuildDependencies, action_root.join("install_openshift2_build_dependencies")
-      autoload :BuildOpenshift3Images, action_root.join("build_openshift3_images")
-      autoload :BuildOpenshift3InfrastructureImages, action_root.join("build_openshift3_infrastructure_images")
       autoload :InstallOpenshift3BaseDependencies, action_root.join("install_openshift3_base_dependencies")
-      autoload :InstallOpenshift3Images, action_root.join("install_openshift3_images")
+      autoload :BuildOpenshift3BaseImages, action_root.join("build_openshift3_base_images")
+      autoload :PushOpenshift3Release, action_root.join("push_openshift3_release")
       autoload :InstallOpenshift3, action_root.join("install_openshift3")
       autoload :BuildOpenshift3, action_root.join("build_openshift3")
       autoload :TryRestartOpenshift3, action_root.join("try_restart_openshift3")

--- a/lib/vagrant-openshift/action/install_openshift3_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_openshift3_base_dependencies.rb
@@ -42,8 +42,6 @@ systemctl enable docker
 systemctl start docker
 
 docker pull openshift/docker-registry
-docker pull openshift/docker-builder
-docker pull openshift/sti-builder
 
 touch #{Vagrant::Openshift::Constants.deps_marker}
           }, {:timeout=>60*20})

--- a/lib/vagrant-openshift/command/build_openshift3.rb
+++ b/lib/vagrant-openshift/command/build_openshift3.rb
@@ -29,10 +29,19 @@ module Vagrant
           options = {}
           options[:clean] = false
           options[:local_source] = false
+          options[:images] = false
+          options[:force] = false
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant build-openshift3 [vm-name]"
             o.separator ""
+
+            o.on("--images", "Build the images as well as core content.") do |c|
+              options[:images] = true
+            end
+            o.on("--force", "Build regardless of whether there have been changes.") do |c|
+              options[:force] = true
+            end
           end
 
           # Parse the options

--- a/lib/vagrant-openshift/command/build_openshift3_base_images.rb
+++ b/lib/vagrant-openshift/command/build_openshift3_base_images.rb
@@ -18,7 +18,7 @@ require_relative "../action"
 module Vagrant
   module Openshift
     module Commands
-      class BuildOpenshift3InfrastructureImages < Vagrant.plugin(2, :command)
+      class BuildOpenshift3BaseImages < Vagrant.plugin(2, :command)
         include CommandHelper
 
         def self.synopsis
@@ -31,25 +31,16 @@ module Vagrant
           options[:local_source] = false
 
           opts = OptionParser.new do |o|
-            o.banner = "Usage: vagrant build-openshift3-infrastructure-images --images image_name [vm-name]"
+            o.banner = "Usage: vagrant build-openshift3-base-images"
             o.separator ""
-
-            o.on("--images #{Vagrant::Openshift::Constants.openshift3_infrastructure_images.keys.join(' ')} | all", "Specify which images should be built. Default: []") do |f|
-              if f.split(" ").include?("all")
-                options[:openshift3_infrastructure_images] = Vagrant::Openshift::Constants.openshift3_infrastructure_images.keys
-              else
-                options[:openshift3_infrastructure_images] = f.split(" ")
-              end
-            end
           end
 
           # Parse the options
           argv = parse_options(opts)
           return if !argv
-          raise Vagrant::Errors::CLIInvalidUsage, help: opts.help.chomp unless options[:openshift3_infrastructure_images]
 
           with_target_vms(argv, :reverse => true) do |machine|
-            actions = Vagrant::Openshift::Action.build_openshift3_infrastructure_images(options)
+            actions = Vagrant::Openshift::Action.build_openshift3_base_images(options)
             @env.action_runner.run actions, {:machine => machine}
             0
           end

--- a/lib/vagrant-openshift/command/repo_sync_openshift3.rb
+++ b/lib/vagrant-openshift/command/repo_sync_openshift3.rb
@@ -27,7 +27,7 @@ module Vagrant
 
         def execute
           options = {}
-          options[:openshift3_images] = []
+          options[:images] = true
           options[:no_build] = false
           options[:clean] = false
           options[:source] = false
@@ -51,14 +51,6 @@ module Vagrant
 
             o.on("-i [comp comp]", "--include", String, "Sync specified components.  Default: #{options[:include].join " "}") do |f|
               options[:include] = f.split " "
-            end
-
-            o.on("--openshift3-images [ #{Vagrant::Openshift::Constants.openshift3_images.keys.join(' ')} | all ]", "Specify which images should be synced.   Default: []") do |f|
-              if f.split(" ").include?("all")
-                options[:openshift3_images] = Vagrant::Openshift::Constants.openshift3_images.keys
-              else
-                options[:openshift3_images] = f.split(" ")
-              end
             end
           end
 

--- a/lib/vagrant-openshift/constants.rb
+++ b/lib/vagrant-openshift/constants.rb
@@ -56,13 +56,6 @@ module Vagrant
         }
       end
 
-      def self.openshift3_infrastructure_images
-        {
-          'sti-builder' => 'origin/images/builder/docker/sti-builder',
-          'docker-builder' => 'origin/images/builder/docker/docker-builder'
-        }
-      end
-
       def self.images
         [
           'centos'

--- a/lib/vagrant-openshift/plugin.rb
+++ b/lib/vagrant-openshift/plugin.rb
@@ -67,14 +67,9 @@ module Vagrant
         Commands::TryRestartOpenshift3
       end
 
-      command "build-openshift3-images" do
-        require_relative "command/build_openshift3_images"
-        Commands::BuildOpenshift3Images
-      end
-
-      command "build-openshift3-infrastructure-images" do
-        require_relative "command/build_openshift3_infrastructure_images"
-        Commands::BuildOpenshift3InfrastructureImages
+      command "build-openshift3-base-images" do
+        require_relative "command/build_openshift3_base_images"
+        Commands::BuildOpenshift3BaseImages
       end
 
       command "origin-init" do
@@ -90,6 +85,11 @@ module Vagrant
       command "openshift3-local-checkout" do
         require_relative "command/local_openshift3_setup"
         Commands::LocalOpenshift3Setup
+      end
+
+      command "push-openshift3-release" do
+        require_relative "command/push_openshift3_release"
+        Commands::PushOpenshift3Release
       end
 
       command "test-openshift2" do


### PR DESCRIPTION
Organize Docker Builds more effectively, and use build-release.sh to build our binaries

Split Base image building from regular images (make those part of build) and remove
some arbitrary Docker building.
