### PR TITLE
handle kubernetes services with random ips

### DIFF
--- a/lib/vagrant-openshift/action/install_openshift3_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_openshift3_base_dependencies.rb
@@ -46,7 +46,7 @@ setenforce 0
 
 usermod -a -G docker #{ssh_user}
 
-sed -i 's,^OPTIONS=--selinux-enabled.*,OPTIONS=--selinux-enabled --insecure-registry=172.121.17.1:5001 --insecure-registry=172.121.17.3:5001,' /etc/sysconfig/docker
+sed -i 's,^OPTIONS=--selinux-enabled.*,OPTIONS=--selinux-enabled --insecure-registry=172.121.17.0/24,' /etc/sysconfig/docker
 
 # Force socket reuse
 echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse


### PR DESCRIPTION
Kubernetes services now randomize their IPs.  That means that the services we use for docker registries during our tests are no longer on predictable ips.  This tweaks the insecure ips to allow the entire default portal-net range.

Without it, you end up with errors like this: 

```
Error: Invalid registry endpoint https://172.121.17.215:5001/v1/: Get https://172.121.17.215:5001/v1/_ping: EOF. If this private registry supports only HTTP or HTTPS with an unknown CA certificate, please add `--insecure-registry 172.121.17.215:5001` to the daemon's arguments. In the case of HTTPS, if you have access to the registry's CA certificate, no need for the flag; simply place the CA certificate at /etc/docker/certs.d/172.121.17.215:5001/ca.crt
```

from https://ci.openshift.redhat.com/jenkins/job/test_pull_requests_openshift3/587/console .

I don't know to test this change, but the range looks legal according to this: https://docs.docker.com/reference/commandline/cli/#daemon.  You can test it by running the changes for https://github.com/openshift/origin/pull/483.
