### PR TITLE
fix for private service ip range

### DIFF
--- a/lib/vagrant-openshift/action/install_openshift3_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_openshift3_base_dependencies.rb
@@ -46,7 +46,7 @@ setenforce 0
 
 usermod -a -G docker #{ssh_user}
 
-sed -i 's,^OPTIONS=--selinux-enabled.*,OPTIONS=--selinux-enabled --insecure-registry=172.121.17.1:5001 --insecure-registry=172.121.17.3:5001 --insecure-registry="172.121.17.0/24",' /etc/sysconfig/docker
+sed -i 's,^OPTIONS=--selinux-enabled.*,OPTIONS=--selinux-enabled --insecure-registry=172.121.17.1:5001 --insecure-registry=172.121.17.3:5001 --insecure-registry="172.121.17.0/24 --insecure-registry="172.30.17.0/24",' /etc/sysconfig/docker
 
 # Force socket reuse
 echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse


### PR DESCRIPTION
Issue https://github.com/openshift/origin/issues/551 points out that 172.121.17.0/24 is not private.  Switching to 172.30.17.0/24 which is private (http://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces), but that requires an update to the jenkins image in order to be able to use the registry that we create.

This update keeps the 172.121.17 range as insecure, so nothing breaks unexpected before https://github.com/openshift/origin/issues/551 is resolved.
