### PR TITLE
Accommodate empty lines in ~/.awscred

### DIFF
--- a/lib/vagrant-openshift/action/generate_template.rb
+++ b/lib/vagrant-openshift/action/generate_template.rb
@@ -109,7 +109,8 @@ module Vagrant
           return if box_info[:aws][:ami_tag_prefix].nil?
           @env[:ui].info("Reading AWS credentials from #{@aws_creds_file.to_s}")
           if @aws_creds_file.exist?
-            aws_creds = @aws_creds_file.exist? ? Hash[*(File.open(@aws_creds_file.to_s).readlines.map{ |l| l.split('=') }.flatten.map{ |i| i.strip })] : {}
+            aws_creds = @aws_creds_file.exist? ? Hash[*(File.open(@aws_creds_file.to_s).readlines.map{ |l| l.strip!
+                                                          l.split('=') }.flatten)] : {}
 
             fog_config = {
                 :provider              => :aws,


### PR DESCRIPTION
Same issue as addressed in openshift/origin@fa4579e3266c4dd715ecc9b0346cd33fc2bd1d58

Empty lines in `~/.awscred` caused the `Array` passed to the `Hash`
constructor to have an odd number of elements, raising an exception. Now
lines are `strip!`ped before `split`ting, and `flatten` discards the empty
`Array`(s) produced as a result.