### PR TITLE
install router as part of installing openshift 3

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -40,6 +40,14 @@ module Vagrant
         end
       end
 
+      def self.install_openshift3_router(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use RunSystemctl, {:action => "start", :service => "openshift"}
+          b.use InstallOpenshift3Router
+          b.use RunSystemctl, {:action => "stop", :service => "openshift"}
+        end
+      end
+
       def self.install_openshift3_assets_base(options)
         Vagrant::Action::Builder.new.tap do |b|
           b.use InstallOpenshift3AssetDependencies
@@ -60,7 +68,7 @@ module Vagrant
 
       def self.try_restart_openshift3(options)
         Vagrant::Action::Builder.new.tap do |b|
-          b.use TryRestartOpenshift3
+          b.use RunSystemctl, {:action => "try-restart", :service => "openshift"}
         end
       end
 
@@ -85,7 +93,7 @@ module Vagrant
           if options[:build]
             b.use(BuildOpenshift3BaseImages, options) if options[:images]
             b.use(BuildOpenshift3, options)
-            b.use(TryRestartOpenshift3)
+            b.use RunSystemctl, {:action => "try-restart", :service => "openshift"}
           end
         end
       end
@@ -206,7 +214,6 @@ module Vagrant
       autoload :InstallOpenshift3Rhel7, action_root.join("install_openshift3_rhel7")
       autoload :BuildOpenshift3, action_root.join("build_openshift3")
       autoload :BuildSti, action_root.join("build_sti")
-      autoload :TryRestartOpenshift3, action_root.join("try_restart_openshift3")
       autoload :PrepareSshConfig, action_root.join("prepare_ssh_config")
       autoload :SyncLocalRepository, action_root.join("sync_local_repository")
       autoload :SyncUpstreamRepository, action_root.join("sync_upstream_repository")
@@ -223,6 +230,8 @@ module Vagrant
       autoload :TestExitCode, action_root.join("test_exit_code")
       autoload :CleanNetworkSetup, action_root.join("clean_network_setup")
       autoload :SetupBindHost, action_root.join("setup_bind_host")
+      autoload :InstallOpenshift3Router, action_root.join("install_openshift3_router")
+      autoload :RunSystemctl, action_root.join("run_systemctl")
     end
   end
 end

--- a/lib/vagrant-openshift/action/install_openshift3_router.rb
+++ b/lib/vagrant-openshift/action/install_openshift3_router.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright 2013 Red Hat, Inc.
+# Copyright 2014 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module Vagrant
   module Openshift
     module Action
-      class TryRestartOpenshift3
+      class InstallOpenshift3Router
         include CommandHelper
 
         def initialize(app, env)
@@ -26,11 +26,28 @@ module Vagrant
         end
 
         def call(env)
-          sudo(env[:machine], "systemctl try-restart openshift")
+          puts 'Installing router'
+          sudo(env[:machine], '
+ROUTER_EXISTS=$(openshift ex router 2>&1 | grep "does not exist")
+OS_RUNNING=$(systemctl status openshift | grep "(running)")
+CMD="openshift ex router --create --credentials=${KUBECONFIG}"
+
+if [[ $OS_RUNNING ]]; then
+  if [[ -n $ROUTER_EXISTS ]]; then
+    echo "Installing OpenShift router"
+    ${CMD}
+  else
+    echo "Router already exists, skipping"
+  fi
+else
+  echo "The OpenShift process is not running.  To install a router please start OpenShift and run ${CMD}"
+fi
+
+
+')
 
           @app.call(env)
         end
-
       end
     end
   end

--- a/lib/vagrant-openshift/action/run_systemctl.rb
+++ b/lib/vagrant-openshift/action/run_systemctl.rb
@@ -1,0 +1,38 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+module Vagrant
+  module Openshift
+    module Action
+      class RunSystemctl
+        include CommandHelper
+
+        def initialize(app, env, options)
+          @app = app
+          @env = env
+          @options = options
+        end
+
+        def call(env)
+          unless @options[:action].nil? || @options[:service].nil?
+            sudo(env[:machine], "systemctl #{@options[:action]} #{@options[:service]}")
+            @app.call(env)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/command/install_openshift3_router.rb
+++ b/lib/vagrant-openshift/command/install_openshift3_router.rb
@@ -1,0 +1,51 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require_relative "../action"
+
+module Vagrant
+  module Openshift
+    module Commands
+      class InstallOpenshift3Router < Vagrant.plugin(2, :command)
+        include CommandHelper
+
+        def self.synopsis
+          "installs openshift3 router"
+        end
+
+        def execute
+          options = {}
+          options[:clean] = false
+          options[:local_source] = false
+
+          opts = OptionParser.new do |o|
+            o.banner = "Usage: vagrant install-openshift3-router [vm-name]"
+            o.separator ""
+          end
+
+          # Parse the options
+          argv = parse_options(opts)
+          return if !argv
+
+          with_target_vms(argv, :reverse => true) do |machine|
+            actions = Vagrant::Openshift::Action.install_openshift3_router(options)
+            @env.action_runner.run actions, {:machine => machine}
+            0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/plugin.rb
+++ b/lib/vagrant-openshift/plugin.rb
@@ -132,6 +132,11 @@ module Vagrant
         Commands::TestOpenshift3Image
       end
 
+      command "install-openshift3-router" do
+        require_relative "command/install_openshift3_router"
+        Commands::InstallOpenshift3Router
+      end
+
       provisioner(:openshift) do
         require_relative "provisioner"
         Provisioner


### PR DESCRIPTION
Install router as part of doing an install-openshift3.

Changes:

1.  Ensure the install command does a build and starts the service
2.  Add an action that will check for openshift in a running state and run the install command for a default router.  Action should skip installation if default router already exists.
3.  Change try-restart to restart.  Try restart does nothing if the service is not already running.