### PR TITLE
Updating image name and github repo link

### DIFF
--- a/lib/vagrant-openshift/command/test_openshift3_image.rb
+++ b/lib/vagrant-openshift/command/test_openshift3_image.rb
@@ -73,8 +73,8 @@ module Vagrant
             image_version = options[:image_version]
             source = options[:source]
 
-            # image could be centos or openshift/ruby-20-centos
-            # just grab the end (centos or ruby-20-centos)
+            # image could be centos or openshift/ruby-20-centos7
+            # just grab the end (centos or ruby-20-centos7)
             source_dir = File.basename(image)
             app_name = "test-#{source_dir}"
             rc=1

--- a/lib/vagrant-openshift/constants.rb
+++ b/lib/vagrant-openshift/constants.rb
@@ -33,7 +33,7 @@ module Vagrant
       def self.openshift3_images
         {
           'wildfly-8-centos' => 'https://github.com/openshift/wildfly-8-centos.git',
-          'ruby-20-centos' => 'https://github.com/openshift/ruby-20-centos.git'
+          'ruby-20-centos7' => 'https://github.com/openshift/sti-ruby.git'
         }
       end
 


### PR DESCRIPTION
There is a new ruby-20 image(ruby-20-centos7) and we are going to get rid of the old one(ruby-20-centos)