### PR TITLE
Added push_openshift3_images

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -52,6 +52,12 @@ module Vagrant
         end
       end
 
+      def self.push_openshift3_images(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use PushOpenshift3Images, options
+        end
+      end
+
       def self.build_sti(options)
         Vagrant::Action::Builder.new.tap do |b|
           b.use BuildSti, options
@@ -201,6 +207,7 @@ module Vagrant
       autoload :InstallOpenshift3BaseDependencies, action_root.join("install_openshift3_base_dependencies")
       autoload :InstallOpenshift3AssetDependencies, action_root.join("install_openshift3_asset_dependencies")
       autoload :BuildOpenshift3BaseImages, action_root.join("build_openshift3_base_images")
+      autoload :PushOpenshift3Images, action_root.join("push_openshift3_images")
       autoload :PushOpenshift3Release, action_root.join("push_openshift3_release")
       autoload :InstallOpenshift3, action_root.join("install_openshift3")
       autoload :InstallOpenshift3Rhel7, action_root.join("install_openshift3_rhel7")

--- a/lib/vagrant-openshift/action/push_openshift3_images.rb
+++ b/lib/vagrant-openshift/action/push_openshift3_images.rb
@@ -1,0 +1,93 @@
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+module Vagrant
+  module Openshift
+    module Action
+      class PushOpenshift3Images
+        include CommandHelper
+
+        def initialize(app, env, options)
+          @app = app
+          @env = env
+          @options = options
+        end
+
+        # FIXME: This is a temporary fix as the RHEL7 AMI should have this
+        #        registry here already.
+        def fix_insecure_registry_cmd(registry_url)
+          %{
+cat <<EOF > /etc/sysconfig/docker
+OPTIONS='--insecure-registry #{registry_url} --selinux-enabled -H fd://'
+EOF
+systemctl restart docker
+          }
+        end
+
+        def call(env)
+          if @options[:registry].nil?
+            @app.call(env)
+            return
+          end
+          do_execute(env[:machine], fix_insecure_registry_cmd(@options[:registry])) 
+          cmd = "set -x"
+          Vagrant::Openshift::Constants.openshift3_images.each do |name, repo|
+            cmd += %{
+pushd /data/src/github.com
+set -e
+# Remove the directory if already exists (usefull for testing)
+rm -rf ./#{name}
+git clone #{repo} ./#{name}
+set +e
+popd
+
+
+pushd /data/src/github.com/#{name}
+git_ref=$(git rev-parse --short HEAD)
+
+image_pull_spec="#{@options[:registry]}/#{name}:$git_ref"
+
+docker pull $image_pull_spec
+image_found=$?
+
+if [ "$image_found" == "0" ]; then
+  echo "Already have latest $image_pull_spec, noop."
+else
+  echo "Building #{name}:$git_ref..."
+  make build
+
+  if [ "$?" != 0 ]; then
+    echo "Failed to build #{name}:$git_ref"
+  else
+    echo "Tagging and pushing $image_pull_spec"
+    docker tag #{name} $image_pull_spec
+    docker push $image_pull_spec
+
+    echo "Tagging and pushing #{name}:latest"
+    docker tag #{name} #{@options[:registry]}/#{name}:latest 
+    docker push #{@options[:registry]}/#{name}:latest
+  fi
+fi
+popd
+            }
+          end
+          do_execute(env[:machine], cmd) 
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/command/push_openshift3_images.rb
+++ b/lib/vagrant-openshift/command/push_openshift3_images.rb
@@ -1,0 +1,59 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require_relative "../action"
+
+module Vagrant
+  module Openshift
+    module Commands
+
+      class PushOpenshift3Images < Vagrant.plugin(2, :command)
+        include CommandHelper
+
+        def self.synopsis
+          "build and push openshift v3 images"
+        end
+
+        def execute
+          options = {}
+          options[:registry] = nil
+
+          opts = OptionParser.new do |o|
+            o.banner = "Usage: vagrant push-openshift3-images --registry DOCKER_REGISTRY [vm-name]"
+            o.on("--registry [url]", String, "Docker Registry to push images to.") do |c|
+              options[:registry] = c
+            end
+            o.separator ""
+          end
+
+          # Parse the options
+          argv = parse_options(opts)
+          return if !argv
+
+          if options[:registry].nil?
+            @env.ui.warn "You must specify target Docker registry"
+            exit
+          end
+
+          with_target_vms(argv, :reverse => true) do |machine|
+            actions = Vagrant::Openshift::Action.push_openshift3_images(options)
+            @env.action_runner.run actions, {:machine => machine}
+            0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/constants.rb
+++ b/lib/vagrant-openshift/constants.rb
@@ -32,8 +32,10 @@ module Vagrant
 
       def self.openshift3_images
         {
-          'wildfly-8-centos' => 'https://github.com/openshift/wildfly-8-centos.git',
-          'sti-ruby' => 'https://github.com/openshift/sti-ruby.git'
+          'openshift/base-centos7'    => 'https://github.com/openshift/sti-base.git',
+          'openshift/ruby-20-centos7'    => 'https://github.com/openshift/sti-ruby.git',
+          'openshift/nodejs-010-centos7' => 'https://github.com/openshift/sti-nodejs.git',
+          'openshift/mysql-55-centos7'   => 'https://github.com/openshift/mysql.git',
         }
       end
 

--- a/lib/vagrant-openshift/plugin.rb
+++ b/lib/vagrant-openshift/plugin.rb
@@ -77,6 +77,11 @@ module Vagrant
         Commands::BuildOpenshift3BaseImages
       end
 
+      command "push-openshift3-images" do
+        require_relative "command/push_openshift3_images"
+        Commands::PushOpenshift3Images
+      end
+
       command "origin-init" do
         require_relative "command/openshift_init"
         Commands::OpenshiftInit


### PR DESCRIPTION
Usage:

```
vagrant push-openshift3-images --registry=<url>:5000
```

This command will do following with each 'image' repository we have (nodejs, ruby, ...):

1. git clone image repository
2. get git short ref
3. docker pull registry/image_name:GIT_SHORT_REF
4. if image is found then noop, if not found (returns 1) then:
5. make build (builds the image)
6. docker tag registry/image_name:GIT_SHORT_REF
7. docker push registry/image_name:GIT_SHORT_REF 
