### PR TITLE
Added support for RHEL7 for all Docker images

### DIFF
--- a/lib/vagrant-openshift/action/push_openshift3_images.rb
+++ b/lib/vagrant-openshift/action/push_openshift3_images.rb
@@ -45,19 +45,92 @@ if [ ! -f /tmp/push_images_result ]; then
 fi
 
 echo "Sending notifications to #{recipients}"
-echo -e "The list of Docker images pushed to #{registry}:\n\n" >> /tmp/mail_template
+echo -e "The list of Docker images pushed to #{registry}:\n" >> /tmp/mail_template
 
 while read -r line; do
-  ref=$(echo -n $line | cut -d ":" -f 3)
-  name=$(echo -n $line | cut -d "/" -f 2,3 | cut -d ":" -f 1)
-  echo -e "* ${name}" >> /tmp/mail_template
+  image_name=$(echo -n $line | cut -d "/" -f 2,3 | cut -d ":" -f 1)
+  echo "* ${image_name}" >> /tmp/mail_template
   echo -e "  $ docker pull ${line}\n" >> /tmp/mail_template
 done < /tmp/push_images_result
 
 count=$(echo -n `cat /tmp/push_images_result | wc -l`)
-cat /tmp/mail_template | mail -r "Jenkins <noreply@redhat.com>" -s "[Jenkins] ${count} Docker images pushed to #{registry}" #{recipients}
+cat /tmp/mail_template | mail -r "Jenkins <noreply@redhat.com>" \
+  -s "[Jenkins] ${count} Docker images pushed to #{registry}" #{recipients}
+cat /tmp/mail_template
 rm -f /tmp/mail_template /tmp/push_images_result
           }
+        end
+
+        def repos
+          return {}.merge(Vagrant::Openshift::Constants.openshift3_centos7_base).
+            merge(Vagrant::Openshift::Constants.openshift3_rhel7_base).
+            merge(Vagrant::Openshift::Constants.openshift3_centos7_images).
+            merge(Vagrant::Openshift::Constants.openshift3_rhel7_images)
+        end
+
+        def clone_image_repos_cmd(registry)
+          cmd = %{set -e; set -x; cd /data/src/github.com; }
+          # Perform git clone for all images repos in parallel
+          repos.each do |name, git_url|
+            cmd += %{
+            ( rm -rf ./#{name}; git clone -q #{git_url} ./#{name} ) &
+            }
+          end
+          # Wait for the clone to finish
+          cmd += %{
+          echo "Waiting for image GIT repositories to be cloned."
+          wait
+          }
+          repos.each do |name, _|
+            cmd += %{
+rm -rf /tmp/force_rebuild*
+pushd /data/src/github.com/#{name}
+git rev-parse --short HEAD > .git-head
+git_ref=`echo -n $(<.git-head)`
+echo -n "#{registry}/#{name}:$git_ref" > .docker-pull-name
+set +e
+docker pull $(<.docker-pull-name)
+[ "$?" == "0" ] && touch .docker-build-skip
+set -e
+popd
+            }
+          end
+          return cmd
+        end
+
+        def build_image(name, target, base_image, options)
+          cmd = %{
+set +e
+pushd /data/src/github.com/#{name}
+git_ref=$(<.git-head)
+image_name=$(<.docker-pull-name)
+
+if [ -f .docker-build-skip -a ! -f /tmp/force_rebuild-#{target} ]; then
+  echo "Already latest ${image_name} and no base image change, noop."
+else
+  echo "Building #{name}:$git_ref with #{target} target..."
+  make build TARGET=#{target}
+
+  if [ "$?" != 0 ]; then
+    echo "ERROR: Failed to build ${image_name}"
+  else
+    echo "Tagging and pushing $image_name"
+    docker tag #{name} $image_name
+    docker push $image_name
+
+    echo "Tagging and pushing #{name}:latest"
+    docker tag #{name} #{options[:registry]}/#{name}:latest
+    docker push #{options[:registry]}/#{name}:latest
+
+    echo "${image_name}" >> /tmp/push_images_result
+
+    # If this is a base image, force rebuild all image using it
+    [ -z "#{base_image}" ] && touch /tmp/force_rebuild_#{target}
+  fi
+fi
+popd
+          }
+          return cmd
         end
 
         def call(env)
@@ -65,51 +138,26 @@ rm -f /tmp/mail_template /tmp/push_images_result
             @app.call(env)
             return
           end
-          do_execute(env[:machine], fix_insecure_registry_cmd(@options[:registry]))
-          cmd = "set -x"
-          Vagrant::Openshift::Constants.openshift3_images.each do |name, repo|
-            cmd += %{
-pushd /data/src/github.com
-set -e
-# Remove the directory if already exists (usefull for testing)
-rm -rf ./#{name}
-git clone #{repo} ./#{name}
-set +e
-popd
-
-pushd /data/src/github.com/#{name}
-git_ref=$(git rev-parse --short HEAD)
-
-image_pull_spec="#{@options[:registry]}/#{name}:$git_ref"
-
-docker pull $image_pull_spec
-image_found=$?
-
-if [ "$image_found" == "0" ]; then
-  echo "Already have latest $image_pull_spec, noop."
-else
-  echo "Building #{name}:$git_ref..."
-  make build
-
-  if [ "$?" != 0 ]; then
-    echo "Failed to build #{name}:$git_ref"
-  else
-    echo "Tagging and pushing $image_pull_spec"
-    docker tag #{name} $image_pull_spec
-    docker push $image_pull_spec
-
-    echo "Tagging and pushing #{name}:latest"
-    docker tag #{name} #{@options[:registry]}/#{name}:latest
-    docker push #{@options[:registry]}/#{name}:latest
-    echo "${image_pull_spec}" >> /tmp/push_images_result
-  fi
-fi
-popd
-            }
+          cmd = fix_insecure_registry_cmd(@options[:registry])
+          cmd += clone_image_repos_cmd(@options[:registry])
+          # Build base images first
+          Vagrant::Openshift::Constants.openshift3_centos7_base.each do |name, _|
+            cmd += build_image(name, "centos7", "", @options)
           end
+          Vagrant::Openshift::Constants.openshift3_rhel7_base.each do |name, _|
+            cmd += build_image(name, "rhel7", "", @options)
+          end
+          # Other language && STI images
+          Vagrant::Openshift::Constants.openshift3_centos7_images.each do |name, _|
+            cmd += build_image(name, "centos7", "centos7", @options)
+          end
+          Vagrant::Openshift::Constants.openshift3_rhel7_images.each do |name, _|
+            cmd += build_image(name, "rhel7", "rhel7", @options)
+          end
+
           do_execute(env[:machine], cmd)
           do_execute(env[:machine], send_mail_notifications(
-            "libra-dev@redhat.com,jhadvig@redhat.com,mfojtik@redhat.com",
+            "mfojtik@redhat.com",
             @options[:registry]
           ))
           @app.call(env)

--- a/lib/vagrant-openshift/constants.rb
+++ b/lib/vagrant-openshift/constants.rb
@@ -30,19 +30,32 @@ module Vagrant
         }
       end
 
-      def self.openshift3_images
+      def self.openshift3_centos7_base
         {
           'openshift/base-centos7'       => 'https://github.com/openshift/sti-base.git',
+        }
+      end
+
+      def self.openshift3_rhel7_base
+        {
+          'openshift/base-rhel7'       => 'https://github.com/openshift/sti-base.git',
+        }
+      end
+
+      def self.openshift3_centos7_images
+        {
           'openshift/ruby-20-centos7'    => 'https://github.com/openshift/sti-ruby.git',
           'openshift/nodejs-010-centos7' => 'https://github.com/openshift/sti-nodejs.git',
           'openshift/mysql-55-centos7'   => 'https://github.com/openshift/mysql.git',
         }
       end
 
-      def self.images
-        [
-          'centos'
-        ] + openshift3_images.map { |c, _| c }
+      def self.openshift3_rhel7_images
+        {
+          'openshift/ruby-20-rhel7'    => 'https://github.com/openshift/sti-ruby.git',
+          'openshift/nodejs-010-rhel7' => 'https://github.com/openshift/sti-nodejs.git',
+          'openshift/mysql-55-rhel7'   => 'https://github.com/openshift/mysql.git',
+        }
       end
 
       def self.git_branch_current


### PR DESCRIPTION
The summary of what this PR do:

* If the base image (either base-rhel7 or base-centos7) changes, all images are rebuilt and pushed no matter if they were update or not. 
* Send notification with summary of what images were updated and how you can pull them.
* Build all RHEL7 images and push them to the private registry