### PR TITLE
Infrastructure - bootstrap OpenShift3 vagrant image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test/version_tmp
 test/Vagrantfile
 tmp
 vendor
+.vagrant-openshift.json

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -91,6 +91,19 @@ you may modify later to match your vagrant requirements:
 $ vagrant origin-init --stage inst --os (fedora|centos7|rhel7) <instance name>
 ----
 
+If you are building a +bootstrap+ image to package and share with others, use the following:
+
+[source, sh]
+----
+$ vagrant origin-init --stage bootstrap --os (fedora|centos7|rhel7) <instance name> --local-source
+----
+NOTES:
+
+1. See link:#initial-setup[Initial Setup] below for a discussion on your choices for +--stage+.
+
+2. If you use the --local-source flag, a copy of the github origin repository will be installed in the image rather than sync'ed folders.
+This is true for all providers. You can change the brand from +master+ in the `.vagrant-openshift.json` file.
+
 ==== Start the machine
 
 ===== VirtualBox
@@ -385,11 +398,12 @@ Ideally you would be able to use an image with the operating system,
 dependencies, and OpenShift already installed so you can just start
 hacking. But at this time that is not available for all providers.
 
-Images may be thought of as being at one of three stages:
+Images may be thought of as being at one of four stages:
 
 1. "os" - The base OS image (use a "minimal" one).
 2. "deps" - OpenShift runtime dependencies and build requirements are installed.
 3. "inst" - OpenShift code, images, and binaries are built and installed
+4. "bootstrap" -  OpenShift installed and running
 
 You may want to create images that snapshot the output at each of
 these stages, as the rate of change and amount of time to create each
@@ -401,6 +415,7 @@ you will need to install the build tools and other dependencies for
 building and running OpenShift. The following vagrant commands should
 help with this:
 
+[source, sh]
 ----
 $ vagrant build-openshift3-base
 $ vagrant build-openshift3-base-images
@@ -409,22 +424,60 @@ $ vagrant install-openshift3-assets-base
 
 Given this base foundation, you may want to `vagrant package` the result before proceeding to install OpenShift code.
 
+[source, sh]
 ----
 $ vagrant install-openshift3
 $ vagrant build-openshift3-base-images  # pick up updates if older "deps" base reused
-$ vagrant build-openshift3 --images
+$ vagrant build-openshift3 --images # --images not needed for bootstrap stages
 $ vagrant build-sti --binary-only
 ----
 
 You may again wish to package this in order to reuse.
 
-If your provider is not set up to automatically sync changes from a local,
-you may do the following to get the host prepared for a git-based sync
-and then use that:
+If you want an image with:
+* enabled and running openshift
+* deployed docker registry
+* deployed routing layer
+* Sample project named 'Turbo'
 
+[source, sh]
+----
+$ vagrant bootstrap-openshift3
+----
+
+You should package this image so it will be easier for you to restore to a known state. If you used the +--local-source+ flag during the +origin-init+ this packed image may be shared with others.
+
+If you want to use this image for OpenShift platform development and if your provider is not set up to automatically sync changes from a local, you may do the following to get the host prepared for a git-based sync and then use that:
+[source, sh]
 ----
 $ vagrant clone-upstream-repos  # and then to git sync and build:
 $ vagrant sync-openshift3 -s
+----
+
+=== Cliff Notes for bootstrap stage vagrant box
+
+Assuming you are targeting the v0.4.4 for your vagrant box
+
+[source, sh]
+----
+$ unset GOPATH
+$ cd ~/tmp
+$ vagrant openshift3-local-checkout --replace  --branch v0.4.4
+$ pushd origin
+$ vagrant origin-init --stage bootstrap --os fedora openshift3-bootstrap --local-source
+$ cp ~jhonce/Projects/go/src/github.com/openshift/origin/Vagrantfile .
+$ vagrant up
+$ vagrant clone-upstream-repos --clean
+$ vagrant checkout-repos --branch v0.4.4
+$ vagrant install-openshift3
+$ vagrant build-openshift3-base
+$ vagrant build-openshift3-base-images
+$ vagrant build-openshift3 --images  # test --no-images
+$ vagrant build-sti --binary-only
+$ vagrant bootstrap-openshift3
+
+$ rm -f /tmp/openshift3-bootstrap.box
+$ vagrant package --output /tmp/openshift3-bootstrap.box
 ----
 
 == Notice of Export Control Law

--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright 2013 Red Hat, Inc.
+# Copyright 2013-2015 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -204,6 +204,26 @@ module Vagrant
         end
       end
 
+      def self.install_docker_registry
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use InstallDockerRegistry
+        end
+      end
+
+      def self.bootstrap_openshift3(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use RunSystemctl, {:action => 'restart', :service => 'docker'}
+          b.use BootstrapOpenshift3
+          b.use RunSystemctl, {:action => 'enable', :service => 'openshift'}
+          b.use RunSystemctl, {:action => 'start', :service => 'openshift', argv: '--force'}
+          b.use WaitForOpenshift3
+          b.use InstallOpenshift3Router
+          b.use InstallDockerRegistry
+          b.use SetupSamplePolicy
+          b.use CreateSampleProject
+        end
+      end
+
       action_root = Pathname.new(File.expand_path("../action", __FILE__))
       autoload :Clean, action_root.join("clean")
       autoload :CloneUpstreamRepositories, action_root.join("clone_upstream_repositories")
@@ -239,6 +259,11 @@ module Vagrant
       autoload :SetupBindHost, action_root.join("setup_bind_host")
       autoload :InstallOpenshift3Router, action_root.join("install_openshift3_router")
       autoload :RunSystemctl, action_root.join("run_systemctl")
+      autoload :InstallDockerRegistry, action_root.join("install_docker_registry")
+      autoload :WaitForOpenshift3, action_root.join("wait_for_openshift3")
+      autoload :CreateSampleProject, action_root.join("create_sample_project")
+      autoload :SetupSamplePolicy, action_root.join("setup_sample_policy")
+      autoload :BootstrapOpenshift3, action_root.join("bootstrap_openshift3")
     end
   end
 end

--- a/lib/vagrant-openshift/action/bootstrap_openshift3.rb
+++ b/lib/vagrant-openshift/action/bootstrap_openshift3.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright 2013-2015 Red Hat, Inc.
+# Copyright 2015 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,20 +17,16 @@
 module Vagrant
   module Openshift
     module Action
-      class RunSystemctl
+      class BootstrapOpenshift3
         include CommandHelper
-
-        def initialize(app, env, options)
+        def initialize(app, env)
           @app = app
           @env = env
-          @options = options
         end
 
         def call(env)
-          unless @options[:action].nil? || @options[:service].nil?
-            sudo(env[:machine], "systemctl #{@options[:action]} #{@options[:service]} #{@options[:argv]}")
-            @app.call(env)
-          end
+          do_execute(env[:machine], %q[echo "Bootstrap OpenShift3 Environment"])
+          @app.call(env)
         end
       end
     end

--- a/lib/vagrant-openshift/action/create_sample_project.rb
+++ b/lib/vagrant-openshift/action/create_sample_project.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright 2013-2015 Red Hat, Inc.
+# Copyright 2015 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,20 +17,21 @@
 module Vagrant
   module Openshift
     module Action
-      class RunSystemctl
+      class CreateSampleProject
         include CommandHelper
 
-        def initialize(app, env, options)
+        def initialize(app, env)
           @app = app
-          @env = env
-          @options = options
         end
 
         def call(env)
-          unless @options[:action].nil? || @options[:service].nil?
-            sudo(env[:machine], "systemctl #{@options[:action]} #{@options[:service]} #{@options[:argv]}")
-            @app.call(env)
-          end
+          puts %q[Creating sample OpenShift3 project 'Turbo']
+
+          sudo(env[:machine], %q[
+              openshift admin new-project turbo --admin=admin --description='Turbo Sample' --display-name='Turbo Sample'
+          ])
+
+          @app.call(env)
         end
       end
     end

--- a/lib/vagrant-openshift/action/generate_template.rb
+++ b/lib/vagrant-openshift/action/generate_template.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright 2013 Red Hat, Inc.
+# Copyright 2013-2015 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,9 +67,14 @@ module Vagrant
             'cpus' => 2,
             'memory' => 1024,
             'rebuild_yum_cache' => false,
-            'sync_to' => '/data/src',
-            'sync_from' => "#{gopath}/src"
           }
+
+          vagrant_openshift_config['local_source'] = @options[:local_source]
+          unless @options[:local_source]
+            vagrant_openshift_config['sync_to']   = '/data/src'
+            vagrant_openshift_config['sync_from'] = "#{gopath}/src"
+          end
+
           vagrant_openshift_config['virtualbox'] = {
             'box_name' => box_info[:virtualbox][:box_name],
             'box_url' => box_info[:virtualbox][:box_url]
@@ -103,7 +108,7 @@ module Vagrant
         private
 
         def find_ami_from_tag(box_info)
-          return if box_info[:aws][:ami_tag_prefix].nil?
+          return if box_info[:aws].nil? || box_info[:aws][:ami_tag_prefix].nil?
           @env[:ui].info("Reading AWS credentials from #{@aws_creds_file.to_s}")
           if @aws_creds_file.exist?
             aws_creds = @aws_creds_file.exist? ? Hash[*(File.open(@aws_creds_file.to_s).readlines.map{ |l| l.strip!

--- a/lib/vagrant-openshift/action/install_openshift3_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_openshift3_base_dependencies.rb
@@ -47,7 +47,7 @@ setenforce 0
 
 systemctl enable ntpd
 
-groupadd docker
+groupadd -f docker
 usermod -a -G docker #{ssh_user}
 
 sed -i "s,^OPTIONS='\\(.*\\)',OPTIONS='--insecure-registry=172.30.0.0/16 \\1'," /etc/sysconfig/docker

--- a/lib/vagrant-openshift/action/install_openshift3_router.rb
+++ b/lib/vagrant-openshift/action/install_openshift3_router.rb
@@ -28,12 +28,12 @@ module Vagrant
         def call(env)
           puts 'Installing router'
           sudo(env[:machine], '
-ROUTER_EXISTS=$(openshift ex router 2>&1 | grep "does not exist")
 OS_RUNNING=$(systemctl status openshift | grep "(running)")
 CMD="openshift ex router --create --credentials=${OPENSHIFTCONFIG}"
 
 if [[ $OS_RUNNING ]]; then
-  if [[ -n $ROUTER_EXISTS ]]; then
+  ROUTER_EXISTS=$(openshift ex router --credentials=${OPENSHIFTCONFIG} 2>&1 | grep "service exists")
+  if [[ -z $ROUTER_EXISTS ]]; then
     echo "Installing OpenShift router"
     ${CMD}
   else

--- a/lib/vagrant-openshift/action/setup_sample_policy.rb
+++ b/lib/vagrant-openshift/action/setup_sample_policy.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright 2013-2015 Red Hat, Inc.
+# Copyright 2015 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,20 +17,24 @@
 module Vagrant
   module Openshift
     module Action
-      class RunSystemctl
+      class SetupSamplePolicy
         include CommandHelper
 
-        def initialize(app, env, options)
+        def initialize(app, env)
           @app = app
-          @env = env
-          @options = options
         end
 
         def call(env)
-          unless @options[:action].nil? || @options[:service].nil?
-            sudo(env[:machine], "systemctl #{@options[:action]} #{@options[:service]} #{@options[:argv]}")
-            @app.call(env)
-          end
+          puts 'Creating cluster-admin policy'
+
+          sudo(env[:machine], %q[
+#set -x
+
+source /etc/profile.d/openshift.sh
+openshift admin policy add-role-to-group cluster-admin system:authenticated --config=${OPENSHIFTCONFIG} --namespace=master
+          ])
+
+          @app.call(env)
         end
       end
     end

--- a/lib/vagrant-openshift/action/wait_for_openshift3.rb
+++ b/lib/vagrant-openshift/action/wait_for_openshift3.rb
@@ -1,0 +1,61 @@
+#--
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require 'open-uri'
+require 'openssl'
+require 'uri'
+
+module Vagrant
+  module Openshift
+    module Action
+      class WaitForOpenshift3
+        include CommandHelper
+
+        def initialize(app, env)
+          @app = app
+          @env = env
+        end
+
+        def call(env)
+          puts 'Waiting on origin...'
+
+          uri    = URI.parse('https://localhost:8443/api')
+          status = nil
+          begin
+            until '200' == status
+              uri.open(ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE, read_timeout: 10) do |response|
+                status = response.status[0]
+                if '200' == status
+                  puts "...#{response.status[1]}"
+                else
+                  puts "...#{response.status[1]}:#{status}"
+                  sleep 1
+                end
+              end
+            end
+          rescue OpenSSL::SSL::SSLError, Errno::ECONNRESET, OpenURI::HTTPError
+            sleep 1
+            retry
+          rescue => e
+            puts "#{e.class}: #{e.message}"
+            exit
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/command/bootstrap_openshift3.rb
+++ b/lib/vagrant-openshift/command/bootstrap_openshift3.rb
@@ -1,0 +1,51 @@
+#--
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require_relative '../action'
+
+module Vagrant
+  module Openshift
+    module Commands
+      class BootstrapOpenshift3 < Vagrant.plugin(2, :command)
+        include CommandHelper
+
+        def self.synopsis
+          'Configures openshift3 with sample project "Turbo"'
+        end
+
+        def execute
+          options = {}
+          options[:clean] = false
+          options[:local_source] = false
+
+          opts = OptionParser.new do |o|
+            o.banner = 'Usage: vagrant bootstrap-openshift3 [vm-name]'
+            o.separator ''
+          end
+
+          # Parse the options
+          argv = parse_options(opts)
+          return if !argv
+
+          with_target_vms(argv, :reverse => true) do |machine|
+            actions = Vagrant::Openshift::Action.bootstrap_openshift3(options)
+            @env.action_runner.run actions, {:machine => machine}
+            0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/command/install_docker_registry.rb
+++ b/lib/vagrant-openshift/command/install_docker_registry.rb
@@ -1,0 +1,51 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require_relative "../action"
+
+module Vagrant
+  module Openshift
+    module Commands
+      class InstallDockerRegistry < Vagrant.plugin(2, :command)
+        include CommandHelper
+
+        def self.synopsis
+          "installs docker registry as container"
+        end
+
+        def execute
+          options = {}
+          options[:clean] = false
+          options[:local_source] = false
+
+          opts = OptionParser.new do |o|
+            o.banner = "Usage: vagrant install-docker-registry [vm-name]"
+            o.separator ""
+          end
+
+          # Parse the options
+          argv = parse_options(opts)
+          return if !argv
+
+          with_target_vms(argv, :reverse => true) do |machine|
+            actions = Vagrant::Openshift::Action.install_docker_registry(options)
+            @env.action_runner.run actions, {:machine => machine}
+            0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/command/openshift_init.rb
+++ b/lib/vagrant-openshift/command/openshift_init.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright 2013 Red Hat, Inc.
+# Copyright 2013-2015 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,17 +30,18 @@ module Vagrant
             :no_base  => false,
             :os       => 'centos7',
             :stage    => 'inst',
-            :port_mappings => []
+            :port_mappings => [],
+            :local_source => false,
           }
 
-          valid_stage = ['os','deps','inst']
+          valid_stage = ['os','deps','inst', 'bootstrap']
           valid_os = ['centos7','fedora','rhel7']
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant origin-init [vm or instance name]"
             o.separator ""
 
-            o.on("-s [stage]", "--stage [stage]", String, "Specify what build state to start from:\n\tos = base operating system\n\tdeps = only dependencies installed\n\tinst = dev environment [default]") do |f|
+            o.on("-s [stage]", "--stage [stage]", String, "Specify what build state to start from:\n\tos = base operating system\n\tdeps = only dependencies installed\n\tinst = dev environment [default]\n\tbootstrap = running environment") do |f|
               options[:stage] = f
             end
 
@@ -50,6 +51,10 @@ module Vagrant
 
             o.on("-p [guest_port:host_port]", "--map-port [guest_port:host_port]", String, "When running on VirtualBox, map port from guest docker vm to host machine") do |f|
               options[:port_mappings].push(f.split(":"))
+            end
+
+            o.on('--local-source', 'Checkout source into image rather than mapping from host system') do |f|
+              options[:local_source] = true
             end
           end
 

--- a/lib/vagrant-openshift/plugin.rb
+++ b/lib/vagrant-openshift/plugin.rb
@@ -1,5 +1,5 @@
 #--
-# Copyright 2013 Red Hat, Inc.
+# Copyright 2013-2015 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -140,6 +140,16 @@ module Vagrant
       command "install-openshift3-router" do
         require_relative "command/install_openshift3_router"
         Commands::InstallOpenshift3Router
+      end
+
+      command "install-docker-registry" do
+        require_relative 'command/install_docker_registry'
+        Commands::InstallDockerRegistry
+      end
+
+      command "bootstrap-openshift3" do
+        require_relative 'command/bootstrap_openshift3'
+        Commands::BootstrapOpenshift3
       end
 
       provisioner(:openshift) do

--- a/lib/vagrant-openshift/templates/command/init-openshift/box_info.yaml
+++ b/lib/vagrant-openshift/templates/command/init-openshift/box_info.yaml
@@ -54,6 +54,13 @@
       :image: <CentOS 7>
       :flavor: m1.small
       :ssh_user: centos
+  :bootstrap:
+    :virtualbox:
+      :box_name: centos7_inst
+      :box_url: http://mirror.openshift.com/pub/vagrant/boxes/openshift3/centos7_virtualbox_inst.box
+    :libvirt:
+      :box_name: centos7_base
+      :box_url: http://mirror.openshift.com/pub/vagrant/boxes/openshift3/centos7_libvirt_inst.box
 :fedora:
   :os:
     :virtualbox:
@@ -109,6 +116,13 @@
     :libvirt:
       :box_name: fedora_inst
       :box_url: https://mirror.openshift.com/pub/vagrant/boxes/openshift3/fedora_libvirt_inst.box
+  :bootstrap:
+    :virtualbox:
+      :box_name: fedora_inst
+      :box_url: http://mirror.openshift.com/pub/vagrant/boxes/openshift3/fedora_virtualbox_inst.box
+    :libvirt:
+      :box_name: fedora_inst
+      :box_url: http://mirror.openshift.com/pub/vagrant/boxes/openshift3/fedora_libvirt_inst.box
 :rhel7:
   :os:
     :aws:
@@ -146,3 +160,10 @@
       :image: <RHEL 7>
       :flavor: m1.small
       :ssh_user: root
+  :bootstrap:
+    :virtualbox:
+      :box_name: rhel_inst
+      :box_url: http://mirror.openshift.com/pub/vagrant/boxes/openshift3/rhel_virtualbox_inst.box
+    :libvirt:
+      :box_name: rhel_inst
+      :box_url: http://mirror.openshift.com/pub/vagrant/boxes/openshift3/rhel_libvirt_inst.box


### PR DESCRIPTION
* Add bootstrap-openshift3 action
* Add install-docker-registry action
* Added --local-source option to origin-init action. Copies source
  rather than sync'ing folders
* Updated documentation for 'bootstrap' stage
* Create sample project 'Turbo'

Combined with https://github.com/openshift/origin/pull/1917 this pull request supports installing and configuring a sample OpenShift project.