### PR TITLE
Increase ulimit to 4096

### DIFF
--- a/lib/vagrant-openshift/action/install_openshift.rb
+++ b/lib/vagrant-openshift/action/install_openshift.rb
@@ -85,6 +85,7 @@ Documentation=https://github.com/openshift/origin
 Type=simple
 EnvironmentFile=-/etc/sysconfig/openshift
 ExecStart=$ORIGIN_PATH/_output/local/go/bin/openshift start --cors-allowed-origins=.* --public-master=https://\\${HOST}:8443
+LimitNOFILE=4096
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
@danmcp - the default ulimit of 1024 is far too low when you start working with larger number of objects, or when etcd does a snapshot.

bumping it up to 4096 has shown me no problem.

Fixes https://github.com/openshift/origin/issues/3202