### PR TITLE
Skip squashing test candidate image to speed up push_images

### DIFF
--- a/lib/vagrant-openshift/action/push_openshift_images.rb
+++ b/lib/vagrant-openshift/action/push_openshift_images.rb
@@ -70,10 +70,10 @@ git init && git remote add -t master origin #{repo_url}
 git fetch && git checkout #{git_ref}
 git_ref=$(git rev-parse --short HEAD)
 echo "Building and testing #{image_name}-centos7:$git_ref ..."
-make test TARGET=centos7
+SKIP_SQUASH=1 make test TARGET=centos7
 make build TARGET=centos7
 echo "Building and testing #{image_name}-rhel7:$git_ref ..."
-make test TARGET=rhel7
+SKIP_SQUASH=1 make test TARGET=rhel7
 make build TARGET=rhel7
 popd
 set +e


### PR DESCRIPTION
@bparees do we want to squash the 'candidate' images? (what is the chance that squashing will alter the tested images in a way that the output (squashed image) will behave differently?

The squashing is taking a significant portion of time during the testing (and you also can't re-use the existing layers when you do make build)