### PR TITLE
add support for extended tests

### DIFF
--- a/lib/vagrant-openshift/action/run_openshift_tests.rb
+++ b/lib/vagrant-openshift/action/run_openshift_tests.rb
@@ -92,6 +92,12 @@ popd >/dev/null
           cmd = cmd_env.join(' ') + ' ' + build_targets.join(' ')
           env[:test_exit_code] = run_tests(env, [cmd], true)
 
+          if env[:test_exit_code] == 0 && @options[:extended_test_packages].length > 0
+            extended_cmd = 'hack/test-extended.sh ' + Shellwords.escape(@options[:extended_test_packages])
+            env[:test_exit_code] = run_tests(env, [extended_cmd], true)
+          end
+
+
           # any other tests that should not be run as sudo
           if env[:test_exit_code] == 0 && @options[:all]
             cmds = ['hack/test-assets.sh']

--- a/lib/vagrant-openshift/command/test_openshift.rb
+++ b/lib/vagrant-openshift/command/test_openshift.rb
@@ -29,6 +29,7 @@ module Vagrant
           options = {}
           options[:download] = false
           options[:all] = false
+          options[:extended_test_packages] = ""
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant test-openshift [machine-name]"
@@ -36,6 +37,10 @@ module Vagrant
 
             o.on("-a", "--all", String, "Run all tests") do |f|
               options[:all] = true
+            end
+
+            o.on("-e", "--extended TEST_BUCKETS", String, "Comma delimited list of extended test packages to run") do |f|
+              options[:extended_test_packages] = f
             end
 
             o.on("-d","--artifacts", String, "Download logs") do |f|


### PR DESCRIPTION
Adds a `--extended` flag to `vagrant test-openshift` to specify that you want extended tests run.  This won't do anything unless specified, but if you want it to run you'll need https://github.com/openshift/origin/pull/4033.

@liggitt ptal