### PR TITLE
gather extended test data for artifacts download

### DIFF
--- a/lib/vagrant-openshift/action/download_artifacts_openshift.rb
+++ b/lib/vagrant-openshift/action/download_artifacts_openshift.rb
@@ -38,6 +38,7 @@ module Vagrant
             "/var/log/secure"                      => artifacts_dir + "secure",
             "/var/log/audit/audit.log"             => artifacts_dir + "audit.log",
             "/tmp/origin/e2e/"                     => artifacts_dir + "e2e/",
+            "/tmp/openshift-extended-tests/"       => artifacts_dir + "extended-tests/",
             "/tmp/openshift-cmd/"                  => artifacts_dir + "cmd/",
 
             "/data/src/github.com/openshift/origin/_output/local/releases/" => artifacts_dir + "release/",


### PR DESCRIPTION
@bparees the vagrant-openshift change to include the extended test artifacts in the archive.zip download from Jenkins