### PR TITLE
Upgrade atomic host on AMIs

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -21,6 +21,12 @@ module Vagrant
     module Action
       include Vagrant::Action::Builtin
 
+      def self.build_atomic_host(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use AtomicHostUpgrade
+        end
+      end
+
       def self.build_openshift_base(options)
         Vagrant::Action::Builder.new.tap do |b|
           b.use CreateYumRepositories
@@ -228,6 +234,7 @@ module Vagrant
       autoload :TestExitCode, action_root.join("test_exit_code")
       autoload :CleanNetworkSetup, action_root.join("clean_network_setup")
       autoload :RunSystemctl, action_root.join("run_systemctl")
+      autoload :AtomicHostUpgrade, action_root.join("atomic_host_upgrade")
     end
   end
 end

--- a/lib/vagrant-openshift/action/atomic_host_upgrade.rb
+++ b/lib/vagrant-openshift/action/atomic_host_upgrade.rb
@@ -1,0 +1,36 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+module Vagrant
+  module Openshift
+    module Action
+      class AtomicHostUpgrade
+        include CommandHelper
+
+        def initialize(app, env)
+          @app = app
+          @env = env
+        end
+
+        def call(env)
+          sudo env[:machine], "atomic host upgrade"
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/command/build_atomic_host.rb
+++ b/lib/vagrant-openshift/command/build_atomic_host.rb
@@ -1,0 +1,50 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require_relative "../action"
+
+module Vagrant
+  module Openshift
+    module Commands
+      class BuildAtomicHost < Vagrant.plugin(2, :command)
+        include CommandHelper
+
+        def self.synopsis
+          "Upgrade the atomic host to the latest OStree"
+        end
+
+        def execute
+          options = {}
+          options[:clean] = false
+
+          opts = OptionParser.new do |o|
+            o.banner = "Usage: vagrant build-atomic-host [vm-name]"
+            o.separator ""
+          end
+
+          # Parse the options
+          argv = parse_options(opts)
+          return if !argv
+
+          with_target_vms(argv, :reverse => true) do |machine|
+            actions = Vagrant::Openshift::Action.build_atomic_host(options)
+            @env.action_runner.run actions, {:machine => machine}
+            0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/plugin.rb
+++ b/lib/vagrant-openshift/plugin.rb
@@ -42,6 +42,11 @@ module Vagrant
         Commands::RepoSyncSti
       end
 
+      command "build-atomic-host" do
+        require_relative "command/build_atomic_host"
+        Commands::BuildAtomicHost
+      end
+
       command "build-openshift-base" do
         require_relative "command/build_openshift_base"
         Commands::BuildOpenshiftBase


### PR DESCRIPTION
@danmcp @detiber @brenton 

Currently the repo is registered in the AMIs so all that is required is doing an atomic host upgrade.

CI jobs will be needed to update the images accordingly I will put a trello card in for that.