### PR TITLE
Running the end-to-end tests with sudo prevents chromedriver from lau…

### DIFF
--- a/lib/vagrant-openshift/action/run_openshift_tests.rb
+++ b/lib/vagrant-openshift/action/run_openshift_tests.rb
@@ -91,7 +91,7 @@ popd >/dev/null
           end
 
           cmd = cmd_env.join(' ') + ' ' + build_targets.join(' ')
-          env[:test_exit_code] = run_tests(env, [cmd], true)
+          env[:test_exit_code] = run_tests(env, [cmd], false)
 
           if env[:test_exit_code] == 0 && @options[:extended_test_packages].length > 0
             # for extended tests we need a ginkgo binary


### PR DESCRIPTION
…nching

I ran the 'make test' command manually and as part of the test-openshift plugin
and neither required root.