### PR TITLE
run make -j test

### DIFF
--- a/lib/vagrant-openshift/action/run_openshift_tests.rb
+++ b/lib/vagrant-openshift/action/run_openshift_tests.rb
@@ -68,6 +68,10 @@ popd >/dev/null
 
           cmd_env = []
           build_targets = ["make"]
+          if @options[:parallel]
+            build_targets << '-j'
+            build_targets << '--output-sync=recurse'
+          end
 
           if @options[:all]
             cmd_env << 'ARTIFACT_DIR=/tmp/origin/e2e/artifacts'

--- a/lib/vagrant-openshift/command/test_openshift.rb
+++ b/lib/vagrant-openshift/command/test_openshift.rb
@@ -54,6 +54,10 @@ module Vagrant
             o.on("-c","--report-coverage", String, "Generate code coverage report") do |f|
               options[:report_coverage] = true
             end
+
+            o.on("-j","--parallel", String, "Run parallel make") do |f|
+              options[:parallel] = true
+            end
           end
 
           # Parse the options


### PR DESCRIPTION
Adds a `-j` flag to run `make` with the `-j` flag for parallelism.  The intent is for this to be `false` by default while we see how much it helps and how stable it is on jenkins.

@jwforres ptal