### PR TITLE
add openldap-clients and jq

### DIFF
--- a/lib/vagrant-openshift/action/install_openshift_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_openshift_base_dependencies.rb
@@ -42,7 +42,7 @@ fi
           # FIXME: Move 'openshift/centos-mongodb' into openshift org and then
           #        add the image into 'repositories' constants
           #
-          sudo(env[:machine], "yum install -y git fontconfig yum-utils wget make mlocate bind augeas vim docker-io hg bzr libselinux-devel vim tig glibc-static btrfs-progs-devel device-mapper-devel sqlite-devel libnetfilter_queue-devel gcc gcc-c++ e2fsprogs tmux tmux httpie ctags hg xfsprogs rubygems openvswitch bridge-utils bzip2 ntp screen java-1.?.0-openjdk bind-utils socat unzip Xvfb ethtool", {:timeout=>60*20})
+          sudo(env[:machine], "yum install -y git fontconfig yum-utils wget make mlocate bind augeas vim docker-io hg bzr libselinux-devel vim tig glibc-static btrfs-progs-devel device-mapper-devel sqlite-devel libnetfilter_queue-devel gcc gcc-c++ e2fsprogs tmux tmux httpie ctags hg xfsprogs rubygems openvswitch bridge-utils bzip2 ntp screen java-1.?.0-openjdk bind-utils socat unzip Xvfb ethtool openldap-clients jq", {:timeout=>60*20})
           sudo(env[:machine], "yum install -y facter", {fail_on_error: false, :timeout=>60*10})
 
           # Install Chrome and chromedriver for headless UI testing


### PR DESCRIPTION
We need/want these for ldap group sync extended tests.  `vagrant build-openshift-base` ran successfully for me. See "deads-install-prereq-check" instance. 

@jwforres 