### PR TITLE
Download doesn't need to be verbose on artifacts

### DIFF
--- a/lib/vagrant-openshift/action/download_artifacts_openshift.rb
+++ b/lib/vagrant-openshift/action/download_artifacts_openshift.rb
@@ -54,7 +54,7 @@ module Vagrant
               FileUtils.mkdir_p File.dirname(target.to_s)
             end
 
-            command = "/usr/bin/rsync -avz -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i #{private_key_path}' --rsync-path='sudo rsync' #{ssh_info[:username]}@#{ssh_info[:host]}:#{source} #{target}"
+            command = "/usr/bin/rsync -az -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i #{private_key_path}' --rsync-path='sudo rsync' #{ssh_info[:username]}@#{ssh_info[:host]}:#{source} #{target}"
 
             if not system(command)
               machine.ui.warn "Unable to download artifacts"

--- a/lib/vagrant-openshift/action/download_artifacts_sti.rb
+++ b/lib/vagrant-openshift/action/download_artifacts_sti.rb
@@ -48,7 +48,7 @@ module Vagrant
               FileUtils.mkdir_p File.dirname(target.to_s)
             end
 
-            command = "/usr/bin/rsync -avz -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i #{private_key_path}' --rsync-path='sudo rsync' #{ssh_info[:username]}@#{ssh_info[:host]}:#{source} #{target}"
+            command = "/usr/bin/rsync -az -e 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i #{private_key_path}' --rsync-path='sudo rsync' #{ssh_info[:username]}@#{ssh_info[:host]}:#{source} #{target}"
 
             if not system(command)
               machine.ui.warn "Unable to download artifacts"


### PR DESCRIPTION
We're already seeing too many show up, makes it harder
to debug builds.

@danmcp this makes it much easier to debug failures - anyone
changing this can reenable verbose for debugging.