### PR TITLE
Updated s2i paths to point to new build location

### DIFF
--- a/lib/vagrant-openshift/action/push_openshift_images.rb
+++ b/lib/vagrant-openshift/action/push_openshift_images.rb
@@ -148,7 +148,7 @@ docker pull #{@options[:registry]}openshift/base-rhel7
 
           cmd += %{
 # so we can call s2i
-export PATH=/data/src/github.com/openshift/source-to-image/_output/go/bin:/data/src/github.com/openshift/source-to-image/_output/local/go/bin:$PATH
+export PATH=/data/src/github.com/openshift/source-to-image/_output/local/go/bin:/data/src/github.com/openshift/source-to-image/_output/local/bin/linux/amd64:$PATH
           }
 
           # FIXME: We always need to make sure we have the latest base image

--- a/lib/vagrant-openshift/action/run_sti_tests.rb
+++ b/lib/vagrant-openshift/action/run_sti_tests.rb
@@ -52,7 +52,7 @@ echo '***************************************************'
           _,_,env[:test_exit_code] = sudo(env[:machine], %{
 set -e
 pushd #{Constants.build_dir}/source-to-image >/dev/null
-export PATH=$GOPATH/bin:$PATH:/data/src/github.com/openshift/source-to-image/_output/local/go/bin
+export PATH=/data/src/github.com/openshift/source-to-image/_output/local/go/bin:/data/src/github.com/openshift/source-to-image/_output/local/bin/linux/amd64:$PATH
 #{tests}
 popd >/dev/null
           }, {:timeout => 60*60, :fail_on_error => false, :verbose => false})

--- a/lib/vagrant-openshift/command/test_origin_image.rb
+++ b/lib/vagrant-openshift/command/test_origin_image.rb
@@ -103,7 +103,7 @@ EOF
 fi
 
 # so we can call sti
-export PATH=/data/src/github.com/openshift/source-to-image/_output/go/bin:/data/src/github.com/openshift/source-to-image/_output/local/go/bin:$PATH
+export PATH=/data/src/github.com/openshift/source-to-image/_output/local/go/bin:/data/src/github.com/openshift/source-to-image/_output/local/bin/linux/amd64:$PATH
 
 # create a temp dir to play in
 temp_dir=$(mktemp -d /tmp/image_test.XXXXXXX)


### PR DESCRIPTION
This is needed for https://github.com/openshift/source-to-image/pull/331 to pass and merge and for further s2i images tests.

@bparees ptal