### PR TITLE
added copy for junit artifacts

### DIFF
--- a/lib/vagrant-openshift/action/download_artifacts_origin.rb
+++ b/lib/vagrant-openshift/action/download_artifacts_origin.rb
@@ -40,6 +40,7 @@ module Vagrant
             "/tmp/origin/e2e/"                     => artifacts_dir + "e2e/",
             "/tmp/openshift-extended-tests/"       => artifacts_dir + "extended-tests/",
             "/tmp/openshift-cmd/"                  => artifacts_dir + "cmd/",
+            "/tmp/openshift/junit/report"          => artifacts_dir + "junit/",
 
             "/data/src/github.com/openshift/origin/_output/local/releases/" => artifacts_dir + "release/",
             "/data/src/github.com/openshift/origin/assets/test/tmp/screenshots/" => artifacts_dir + "screenshots/"


### PR DESCRIPTION
Adds a copy action for jUnit artifacts. I've made it a directory as we will potentially have many jUnit logs (`test-go`, `test-integration`, `test-cmd`, extended, e2e, *etc*).

/cc @danmcp 