### PR TITLE
Support configuring testing with an image registry

### DIFF
--- a/lib/vagrant-openshift/action/run_origin_tests.rb
+++ b/lib/vagrant-openshift/action/run_origin_tests.rb
@@ -95,6 +95,10 @@ popd >/dev/null
             cmd_env << 'OUTPUT_COVERAGE=/tmp/origin/e2e/artifacts/coverage'
           end
 
+          if @options[:image_registry]
+            cmd_env << "OPENSHIFT_TEST_IMAGE_REGISTRY=#{@options[:image_registry]}"
+          end
+
           cmd = cmd_env.join(' ') + ' ' + build_targets.join(' ')
           env[:test_exit_code] = run_tests(env, [cmd], false)
 

--- a/lib/vagrant-openshift/command/test_origin.rb
+++ b/lib/vagrant-openshift/command/test_origin.rb
@@ -62,6 +62,10 @@ module Vagrant
             o.on("-j","--parallel", String, "Run parallel make") do |f|
               options[:parallel] = true
             end
+
+            o.on("-r","--image-registry", String, "Image registry to configure tests with") do |f|
+              options[:image_registry] = f
+            end
           end
 
           # Parse the options


### PR DESCRIPTION
For images that are expensive to build (like dind) and change rarely, a
registry can serve as a cache to minimize the cost of test setup.