### PR TITLE
add new download target for tmpdirs

### DIFF
--- a/lib/vagrant-openshift/action/download_artifacts_origin.rb
+++ b/lib/vagrant-openshift/action/download_artifacts_origin.rb
@@ -37,6 +37,7 @@ module Vagrant
             "/var/log/yum.log"                     => artifacts_dir + "yum.log",
             "/var/log/secure"                      => artifacts_dir + "secure",
             "/var/log/audit/audit.log"             => artifacts_dir + "audit.log",
+            "/tmp/openshift/origin"                => artifacts_dir,
             "/tmp/origin/e2e/"                     => artifacts_dir + "e2e/",
             "/tmp/openshift-extended-tests/"       => artifacts_dir + "extended-tests/",
             "/tmp/openshift-cmd/"                  => artifacts_dir + "cmd/",


### PR DESCRIPTION
This PR begins to address https://github.com/openshift/origin/issues/5843.
I add `/tmp/openshift/origin` as a target for download. Once this is rolled into the AMI we use for tests, I'll reconfigure all tests to use this new structure. 

What else needs to be updated that uses the artifacts downloaded?

@danmcp @bparees PTAL