### PR TITLE
Test assets before backing them up

### DIFF
--- a/lib/vagrant-openshift/action/install_origin_asset_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_origin_asset_dependencies.rb
@@ -59,6 +59,10 @@ popd
 
           if @options[:backup_assets]
             cmd += %{
+  # Make sure tests pass before backing up this asset install
+  pushd $ORIGIN_PATH
+    hack/test-assets.sh
+  popd
   mkdir -p $ASSET_BACKUP_DIR
   cp -rf $ORIGIN_PATH/assets/node_modules $ASSET_BACKUP_DIR/node_modules
   cp -rf $ORIGIN_PATH/assets/bower_components $ASSET_BACKUP_DIR/bower_components


### PR DESCRIPTION
Make sure we don't cache a bad asset install to prevent https://github.com/openshift/origin/issues/6651 from happening again