### PR TITLE
Allow makefile targets, use root consistently

### DIFF
--- a/lib/vagrant-openshift/command/test_origin.rb
+++ b/lib/vagrant-openshift/command/test_origin.rb
@@ -35,6 +35,14 @@ module Vagrant
             o.banner = "Usage: vagrant test-origin [machine-name]"
             o.separator ""
 
+            o.on("-t", "--target MAKEFILE_TARGETS", String, "Arguments to pass to the repository Makefile") do |f|
+              options[:target] = f
+            end
+
+            o.on("", "--root", String, "Run tests as root") do |f|
+              options[:root] = true
+            end
+
             o.on("-a", "--all", String, "Run all tests") do |f|
               options[:all] = true
             end


### PR DESCRIPTION
Add --targets (for Makefile execution on tests) and --root (whether
to invoke sudo on the tests). Change tests to default to using not-sudo.

Will be used to help address openshift/origin#6799 by having the jenkins job directly execute specific make targets.