### PR TITLE
blacklisted /volumes/ from rsync download

### DIFF
--- a/lib/vagrant-openshift/action/download_artifacts_origin.rb
+++ b/lib/vagrant-openshift/action/download_artifacts_origin.rb
@@ -55,7 +55,7 @@ module Vagrant
               FileUtils.mkdir_p File.dirname(target.to_s)
             end
 
-            command = "/usr/bin/rsync -az -e 'ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i #{private_key_path}' --rsync-path='sudo rsync' #{ssh_info[:username]}@#{ssh_info[:host]}:#{source} #{target}"
+            command = "/usr/bin/rsync -az -e 'ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i #{private_key_path}' --rsync-path='sudo rsync' --exclude='volumes/*' --exclude='volumes/' #{ssh_info[:username]}@#{ssh_info[:host]}:#{source} #{target}"
 
             if not system(command)
               machine.ui.warn "Unable to download artifacts"


### PR DESCRIPTION
We need two `--exclude=` stanzas as `rsync` uses blobbing instead of regex.

@bparees PTAL
@deads2k FYI

fixes https://github.com/openshift/vagrant-openshift/issues/390