### PR TITLE
add flag to origin test for junit

### DIFF
--- a/lib/vagrant-openshift/action/run_origin_tests.rb
+++ b/lib/vagrant-openshift/action/run_origin_tests.rb
@@ -99,6 +99,10 @@ popd >/dev/null
             cmd_env << 'OUTPUT_COVERAGE=/tmp/origin/e2e/artifacts/coverage'
           end
 
+          if @options[:report_junit]
+            cmd_env << 'JUNIT_REPORT=true'
+          end
+
           if @options[:image_registry]
             cmd_env << "OPENSHIFT_TEST_IMAGE_REGISTRY=#{@options[:image_registry]}"
           end

--- a/lib/vagrant-openshift/command/test_origin.rb
+++ b/lib/vagrant-openshift/command/test_origin.rb
@@ -67,6 +67,10 @@ module Vagrant
               options[:report_coverage] = true
             end
 
+            o.on("","--report-junit", String, "Generate jUnit report") do |f|
+              options[:report_junit] = true
+            end
+
             o.on("-j","--parallel", String, "Run parallel make") do |f|
               options[:parallel] = true
             end


### PR DESCRIPTION
@bparees this adds a `--report-junit` flag to Origin tests so we can support https://github.com/openshift/origin/pull/6604

/cc @deads2k FYI