### PR TITLE
add support for origin-aggregated-logging

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -423,6 +423,56 @@ $ vagrant build-origin --images
 $ vagrant build-sti --binary-only
 ----
 
+=== Testing openshift/origin-aggregated-logging
+
+NOTE: You will still need to clone the OpenShift Origin repo as above, in order
+to use the Vagrantfile and the contrib/vagrant directory.
+origin-aggregated-logging currently has no vagrant support.
+
+==== Clone the OpenShift Origin aggregated logging repositories
+
+Use `vagrant origin-local-checkout` as above link:#clone-the-openshift-origin-repositories[Clone the OpenShift Origin repositories], except use `--repo origin-aggregated-logging`:
+[source, sh]
+----
+$ cd $GOPATH
+$ vagrant origin-local-checkout --repo origin-aggregated-logging -u <github
+username>
+# run the remaining vagrant commands from $GOPATH/src/github.com/openshift/origin
+$ pushd $GOPATH/src/github.com/openshift/origin
+----
+
+==== Initialize local vagrant conf
+
+Same as above for origin - see link:#initialize-local-vagrant-conf[Initialize local vagrant conf]
+You must be in `$GOPATH/src/github.com/openshift/origin` to run this.
+
+==== Start the machine
+
+Same as above for origin - see link:#start-the-machine[Start the machine]
+You must be in `$GOPATH/src/github.com/openshift/origin` to run this.
+
+==== Making Subsequent Changes
+
+* Building updated code from edits in your local repository clones:
+
+[source, sh]
+----
+$ vagrant sync-origin-aggregated-logging
+----
+
+For some providers, your local repositories are automatically synchronized
+to the remote VM. If not, the `--source` option can be used to do so
+before building.
+You must be in `$GOPATH/src/github.com/openshift/origin` to run this.
+
+==== Running Tests
+
+[source, sh]
+----
+$ vagrant test-origin-aggregated-logging [--env NAME=VAR] ...
+----
+You must be in `$GOPATH/src/github.com/openshift/origin` to run this.
+
 == Notice of Export Control Law
 
 This software distribution includes cryptographic software that is subject to the U.S. Export Administration Regulations (the "*EAR*") and other U.S. and foreign laws and may not be exported, re-exported or transferred (a) to any country listed in Country Group E:1 in Supplement No. 1 to part 740 of the EAR (currently, Cuba, Iran, North Korea, Sudan & Syria); (b) to any prohibited destination or to any end user who has been prohibited from participating in U.S. export transactions by any federal agency of the U.S. government; or (c) for use in connection with the design, development or production of nuclear, chemical or biological weapons, or rocket systems, space launch vehicles, or sounding rockets, or unmanned air vehicle systems.You may not download this software or technical information if you are located in one of these countries or otherwise subject to these restrictions. You may not provide this software or technical information to individuals or entities located in one of these countries or otherwise subject to these restrictions. You are also responsible for compliance with foreign law requirements applicable to the import, export and use of this software and technical information.

--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -137,6 +137,26 @@ module Vagrant
         end
       end
 
+      def self.repo_sync_origin_aggregated_logging(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use PrepareSshConfig
+          if options[:source]
+            if options[:clean]
+              b.use(Clean, options)
+              b.use(CloneUpstreamRepositories, options)
+            end
+            b.use(SyncLocalRepository, options)
+            b.use(CheckoutRepositories, options)
+          end
+          # no build support currently
+          # if options[:build]
+          #   b.use(BuildOriginBaseImages, options) if options[:images]
+          #   b.use(BuildOrigin, options)
+          #   b.use RunSystemctl, {:action => "try-restart", :service => "openshift"}
+          # end
+        end
+      end
+
       def self.local_origin_checkout(options)
         Vagrant::Action::Builder.new.tap do |b|
           if not options[:no_build]
@@ -150,6 +170,16 @@ module Vagrant
           b.use RunOriginTests, options
           if options[:download]
             b.use DownloadArtifactsOrigin
+          end
+          b.use TestExitCode
+        end
+      end
+
+      def self.run_origin_aggregated_logging_tests(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use RunOriginAggregatedLoggingTests, options
+          if options[:download]
+            b.use DownloadArtifactsOriginAggregatedLogging
           end
           b.use TestExitCode
         end
@@ -174,6 +204,12 @@ module Vagrant
       def self.download_sti_artifacts(options)
         Vagrant::Action::Builder.new.tap do |b|
           b.use DownloadArtifactsSti
+        end
+      end
+
+      def self.download_origin_aggregated_logging_artifacts(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use DownloadArtifactsOriginAggregatedLogging
         end
       end
 
@@ -255,12 +291,14 @@ module Vagrant
       autoload :CreateBareRepoPlaceholders, action_root.join("create_bare_repo_placeholders")
       autoload :RunOriginTests, action_root.join("run_origin_tests")
       autoload :RunStiTests, action_root.join("run_sti_tests")
+      autoload :RunOriginAggregatedLoggingTests, action_root.join("run_origin_aggregated_logging_tests")
       autoload :GenerateTemplate, action_root.join("generate_template")
       autoload :CreateAMI, action_root.join("create_ami")
       autoload :ModifyInstance, action_root.join("modify_instance")
       autoload :ModifyAMI, action_root.join("modify_ami")
       autoload :DownloadArtifactsOrigin, action_root.join("download_artifacts_origin")
       autoload :DownloadArtifactsSti, action_root.join("download_artifacts_sti")
+      autoload :DownloadArtifactsOriginAggregatedLogging, action_root.join("download_artifacts_origin_aggregated_logging")
       autoload :TestExitCode, action_root.join("test_exit_code")
       autoload :CleanNetworkSetup, action_root.join("clean_network_setup")
       autoload :RunSystemctl, action_root.join("run_systemctl")

--- a/lib/vagrant-openshift/action/checkout_repositories.rb
+++ b/lib/vagrant-openshift/action/checkout_repositories.rb
@@ -28,7 +28,7 @@ module Vagrant
 
         def call(env)
           git_clone_commands = "set -e\n"
-          Constants.repos(env).each do |repo_name, url|
+          Constants.repos_for_name(@options[:repo]).each do |repo_name, url|
             bare_repo_name = repo_name + "-bare"
             bare_repo_path = Constants.build_dir + bare_repo_name
             repo_path = Constants.build_dir + repo_name

--- a/lib/vagrant-openshift/action/clean.rb
+++ b/lib/vagrant-openshift/action/clean.rb
@@ -20,14 +20,15 @@ module Vagrant
       class Clean
         include CommandHelper
 
-        def initialize(app, env)
+        def initialize(app, env, options={})
           @app = app
           @env = env
+          @options = options
         end
 
         def call(env)
           git_clone_commands = ""
-          Constants.repos(env).each do |repo_name, url|
+          Constants.repos_for_name(@options[:repo]).each do |repo_name, url|
             bare_repo_name = repo_name + "-bare"
             wc_repo_name = repo_name + "-bare-working_copy"
             bare_repo_path = Constants.build_dir + bare_repo_name

--- a/lib/vagrant-openshift/action/clone_upstream_repositories.rb
+++ b/lib/vagrant-openshift/action/clone_upstream_repositories.rb
@@ -36,7 +36,7 @@ UserKnownHostsFile=/dev/null
 }}
 
           git_clone_commands = "set -e\n"
-          Constants.repos(env).each do |repo_name, url|
+          Constants.repos_for_name(@options[:repo]).each do |repo_name, url|
             bare_repo_name = repo_name + "-bare"
             bare_repo_path = Constants.build_dir + bare_repo_name
 

--- a/lib/vagrant-openshift/action/download_artifacts_origin_aggregated_logging.rb
+++ b/lib/vagrant-openshift/action/download_artifacts_origin_aggregated_logging.rb
@@ -1,0 +1,67 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require 'pathname'
+
+module Vagrant
+  module Openshift
+    module Action
+      class DownloadArtifactsOriginAggregatedLogging
+        include CommandHelper
+
+        def initialize(app, env)
+          @app = app
+          @env = env
+        end
+
+        def call(env)
+          machine = @env[:machine]
+          machine.ui.info "Downloading logs"
+          ssh_info = machine.ssh_info
+          private_key_path = ssh_info[:private_key_path].kind_of?(Array) ? ssh_info[:private_key_path][0] : ssh_info[:private_key_path]
+
+          artifacts_dir = Pathname.new(File.expand_path(machine.env.root_path + "artifacts"))
+          download_map = {
+            "/var/log/yum.log"                => artifacts_dir + "yum.log",
+            "/var/log/secure"                 => artifacts_dir + "secure",
+            "/var/log/audit/audit.log"        => artifacts_dir + "audit.log",
+            "/tmp/origin-aggregated-logging/" => artifacts_dir,
+          }
+
+          download_map.each do |source,target|
+            if ! machine.communicate.test("sudo ls #{source}")
+              machine.ui.info "#{source} did not exist on the remote system.  This is often the case for tests that were not run."
+              next
+            end
+
+            machine.ui.info "Downloading artifacts from '#{source}' to '#{target}'"
+            if target.to_s.end_with? '/'
+              FileUtils.mkdir_p target.to_s
+            else
+              FileUtils.mkdir_p File.dirname(target.to_s)
+            end
+
+            command = "/usr/bin/rsync -az -e 'ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i #{private_key_path}' --rsync-path='sudo rsync' --exclude='volumes/*' --exclude='volumes/' #{ssh_info[:username]}@#{ssh_info[:host]}:#{source} #{target}"
+
+            if not system(command)
+              machine.ui.warn "Unable to download artifacts"
+            end
+          end
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/action/local_origin_checkout.rb
+++ b/lib/vagrant-openshift/action/local_origin_checkout.rb
@@ -38,7 +38,7 @@ module Vagrant
           end
           Dir.chdir(go_path) do
             commands = "echo 'Waiting for the cloning process to finish'\n"
-            Constants.openshift_repos.each do |repo, url|
+            Constants.repos_for_name(@options[:repo]).each do |repo, url|
               commands += repo_checkout_bash_command(repo, url)
             end
 

--- a/lib/vagrant-openshift/action/run_origin_aggregated_logging_tests.rb
+++ b/lib/vagrant-openshift/action/run_origin_aggregated_logging_tests.rb
@@ -1,0 +1,88 @@
+#--
+# Copyright 2013 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+module Vagrant
+  module Openshift
+    module Action
+      class RunOriginAggregatedLoggingTests
+        include CommandHelper
+
+        @@SSH_TIMEOUT = 4800
+
+        def initialize(app, env, options)
+          @app = app
+          @env = env
+          @options = options.clone
+        end
+
+        def run_tests(env, cmds, as_root=true)
+          tests = ''
+          cmds.each do |cmd|
+            tests += "
+echo '***************************************************'
+echo 'Running #{cmd}...'
+time #{cmd}
+echo 'Finished #{cmd}'
+echo '***************************************************'
+"
+          end
+          cmd = %{
+set -e
+pushd #{Constants.build_dir}/origin-aggregated-logging/hack/testing >/dev/null
+export PATH=$GOPATH/bin:$PATH
+#{tests}
+popd >/dev/null
+        }
+          exit_code = 0
+          if as_root
+            _,_,exit_code = sudo(env[:machine], cmd, {:timeout => 60*60*4, :fail_on_error => false, :verbose => false})
+          else
+            _,_,exit_code = do_execute(env[:machine], cmd, {:timeout => 60*60*4, :fail_on_error => false, :verbose => false})
+          end
+          exit_code
+        end
+
+        #
+        # Build and run the make commands
+        #   for testing all run make test
+        #   for testing unit tests only run make build check
+        #   for testing assets run hack/test-assets.sh
+        #
+        # All env vars will be added to the beginning of the command like VAR=1 make test
+        #
+        def call(env)
+          @options.delete :logs
+
+          cmd_env = []
+
+          if @options[:envs]
+            cmd_env += @options[:envs]
+          end
+
+          if @options[:image_registry]
+            cmd_env << "OPENSHIFT_TEST_IMAGE_REGISTRY=#{@options[:image_registry]}"
+          end
+
+          cmd_env << './logging.sh'
+          cmd = cmd_env.join(' ')
+          env[:test_exit_code] = run_tests(env, [cmd], @options[:root])
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/action/sync_local_repository.rb
+++ b/lib/vagrant-openshift/action/sync_local_repository.rb
@@ -20,15 +20,16 @@ module Vagrant
       class SyncLocalRepository
         include CommandHelper
 
-        def initialize(app, env)
+        def initialize(app, env, options={})
           @app = app
           @env = env
+          @options = options
         end
 
         def call(env)
           env[:machine].env.ui.info("Synchronizing local sources")
 
-          Constants.repos(env).each do |repo_name, url|
+          Constants.repos_for_name(@options[:repo]).each do |repo_name, url|
             local_repo = Pathname.new(File.expand_path(File.join(env[:machine].env.root_path, "..", repo_name)))
             unless local_repo.exist?
               local_repo = Pathname.new(File.expand_path(File.join(env[:machine].env.root_path, repo_name)))

--- a/lib/vagrant-openshift/command/download_artifacts_origin_aggregated_logging.rb
+++ b/lib/vagrant-openshift/command/download_artifacts_origin_aggregated_logging.rb
@@ -18,30 +18,19 @@ require_relative "../action"
 module Vagrant
   module Openshift
     module Commands
-      class CheckoutRepositories < Vagrant.plugin(2, :command)
+      class DownloadArtifactsOriginAggregatedLogging < Vagrant.plugin(2, :command)
         include CommandHelper
 
         def self.synopsis
-          "checkout specified branch from cloned upstream repository"
+          "download the origin-aggregated-logging test artifacts"
         end
 
         def execute
           options = {}
-          options[:repo] = 'origin'
 
           opts = OptionParser.new do |o|
-            o.banner = "Usage: vagrant checkout-repos"
+            o.banner = "Usage: vagrant download-artifacts-origin-aggregated-logging [machine-name]"
             o.separator ""
-
-            o.on("-b [branch-name]", "--branch [branch-name]", String, "Check out the specified branch. Default is 'master'.") do |f|
-              options[:branch] = {"origin-server" => f}
-            end
-
-            o.on("-r [repo-name]", "--repo [repo-name]", String, "Check out the specified repo. Default is 'origin'.") do |f|
-              options[:repo] = f
-            end
-
-           #@options[:branch][repo_name]
           end
 
           # Parse the options
@@ -49,7 +38,7 @@ module Vagrant
           return if !argv
 
           with_target_vms(argv, :reverse => true) do |machine|
-            actions = Vagrant::Openshift::Action.checkout_repositories(options)
+            actions = Vagrant::Openshift::Action.download_origin_aggregated_logging_artifacts(options)
             @env.action_runner.run actions, {:machine => machine}
             0
           end

--- a/lib/vagrant-openshift/command/local_origin_setup.rb
+++ b/lib/vagrant-openshift/command/local_origin_setup.rb
@@ -29,6 +29,7 @@ module Vagrant
           options = {
             :branch => 'master',
             :replace => false,
+            :repo => 'origin'
           }
 
           opts = OptionParser.new do |o|
@@ -45,6 +46,10 @@ module Vagrant
 
             o.on("-r", "--replace", "Delete existing cloned dirs first. Default is to skip repos that are already cloned.") do |f|
               options[:replace] = f
+            end
+
+            o.on("", "--repo [reponame]", "Repo to checkout.  Default is 'origin'.") do |f|
+              options[:repo] = f
             end
           end
 

--- a/lib/vagrant-openshift/command/repo_sync_origin_aggregated_logging.rb
+++ b/lib/vagrant-openshift/command/repo_sync_origin_aggregated_logging.rb
@@ -18,30 +18,41 @@ require_relative "../action"
 module Vagrant
   module Openshift
     module Commands
-      class CheckoutRepositories < Vagrant.plugin(2, :command)
+      class RepoSyncOriginAggregatedLogging < Vagrant.plugin(2, :command)
         include CommandHelper
 
         def self.synopsis
-          "checkout specified branch from cloned upstream repository"
+          "syncs your local repos to the current instance"
         end
 
         def execute
           options = {}
-          options[:repo] = 'origin'
+          options[:images] = true
+          options[:build] = true
+          options[:clean] = false
+          options[:source] = false
+          options[:repo] = 'origin-aggregated-logging'
 
           opts = OptionParser.new do |o|
-            o.banner = "Usage: vagrant checkout-repos"
+            o.banner = "Usage: vagrant sync-origin-aggregated-logging [vm-name]"
             o.separator ""
 
-            o.on("-b [branch-name]", "--branch [branch-name]", String, "Check out the specified branch. Default is 'master'.") do |f|
-              options[:branch] = {"origin-server" => f}
+            o.on("-s", "--source", "Sync the source (not required if using synced folders)") do |f|
+              options[:source] = f
             end
 
-            o.on("-r [repo-name]", "--repo [repo-name]", String, "Check out the specified repo. Default is 'origin'.") do |f|
-              options[:repo] = f
+            o.on("-c", "--clean", "Delete existing repo before syncing source") do |f|
+              options[:clean] = f
             end
 
-           #@options[:branch][repo_name]
+            o.on("--dont-install", "Don't build and install updated source") do |f|
+              options[:build] = false
+            end
+
+            o.on("--no-images", "Don't build updated component Docker images") do |f|
+              options[:images] = false
+            end
+
           end
 
           # Parse the options
@@ -49,7 +60,7 @@ module Vagrant
           return if !argv
 
           with_target_vms(argv, :reverse => true) do |machine|
-            actions = Vagrant::Openshift::Action.checkout_repositories(options)
+            actions = Vagrant::Openshift::Action.repo_sync_origin_aggregated_logging(options)
             @env.action_runner.run actions, {:machine => machine}
             0
           end

--- a/lib/vagrant-openshift/command/test_origin_aggregated_logging.rb
+++ b/lib/vagrant-openshift/command/test_origin_aggregated_logging.rb
@@ -18,30 +18,37 @@ require_relative "../action"
 module Vagrant
   module Openshift
     module Commands
-      class CheckoutRepositories < Vagrant.plugin(2, :command)
+      class TestOriginAggregatedLogging < Vagrant.plugin(2, :command)
         include CommandHelper
 
         def self.synopsis
-          "checkout specified branch from cloned upstream repository"
+          "run the origin-aggregated-logging tests"
         end
 
         def execute
           options = {}
-          options[:repo] = 'origin'
+          options[:download] = false
 
           opts = OptionParser.new do |o|
-            o.banner = "Usage: vagrant checkout-repos"
+            o.banner = "Usage: vagrant test-origin-aggregated-logging [machine-name]"
             o.separator ""
 
-            o.on("-b [branch-name]", "--branch [branch-name]", String, "Check out the specified branch. Default is 'master'.") do |f|
-              options[:branch] = {"origin-server" => f}
+            o.on("", "--root", String, "Run tests as root") do |f|
+              options[:root] = true
             end
 
-            o.on("-r [repo-name]", "--repo [repo-name]", String, "Check out the specified repo. Default is 'origin'.") do |f|
-              options[:repo] = f
+            o.on("-d","--artifacts", String, "Download logs") do |f|
+              options[:download] = true
             end
 
-           #@options[:branch][repo_name]
+            o.on("-r","--image-registry", String, "Image registry to configure tests with") do |f|
+              options[:image_registry] = f
+            end
+
+            o.on("", "--env ENV=VALUE", String, "Environment variable to execute tests with") do |f|
+              options[:envs] = [] unless options[:envs]
+              options[:envs] << f
+            end
           end
 
           # Parse the options
@@ -49,7 +56,7 @@ module Vagrant
           return if !argv
 
           with_target_vms(argv, :reverse => true) do |machine|
-            actions = Vagrant::Openshift::Action.checkout_repositories(options)
+            actions = Vagrant::Openshift::Action.run_origin_aggregated_logging_tests(options)
             @env.action_runner.run actions, {:machine => machine}
             0
           end

--- a/lib/vagrant-openshift/constants.rb
+++ b/lib/vagrant-openshift/constants.rb
@@ -23,6 +23,10 @@ module Vagrant
         openshift_repos
       end
 
+      def self.logging_repos(env)
+        aggregated_logging_repos
+      end
+
       def self.openshift_repos
         {
           'origin' => 'https://github.com/openshift/origin.git',
@@ -30,7 +34,21 @@ module Vagrant
         }
       end
 
-      def self.git_branch_current
+       def self.aggregated_logging_repos
+        {
+          'origin-aggregated-logging' => 'https://github.com/openshift/origin-aggregated-logging.git'
+        }
+      end
+
+      def self.repos_for_name(reponame)
+        {
+          'origin' => openshift_repos,
+          nil => openshift_repos,
+          'origin-aggregated-logging' => aggregated_logging_repos
+        }[reponame]
+      end
+
+     def self.git_branch_current
         "$(git rev-parse --abbrev-ref HEAD)"
       end
 

--- a/lib/vagrant-openshift/plugin.rb
+++ b/lib/vagrant-openshift/plugin.rb
@@ -127,9 +127,19 @@ module Vagrant
         Commands::TestSti
       end
 
+      command "test-origin-aggregated-logging" do
+        require_relative "command/test_origin_aggregated_logging"
+        Commands::TestOriginAggregatedLogging
+      end
+
       command "download-artifacts-origin" do
         require_relative "command/download_artifacts_origin"
         Commands::DownloadArtifactsOrigin
+      end
+
+      command "download-artifacts-origin-aggregated-logging" do
+        require_relative "command/download_artifacts_origin_aggregated_logging"
+        Commands::DownloadArtifactsOriginAggregatedLogging
       end
 
       command "download-artifacts-sti" do
@@ -165,6 +175,11 @@ module Vagrant
       command "test-origin-image" do
         require_relative "command/test_origin_image"
         Commands::TestOriginImage
+      end
+
+      command "sync-origin-aggregated-logging" do
+        require_relative "command/repo_sync_origin_aggregated_logging"
+        Commands::RepoSyncOriginAggregatedLogging
       end
 
       provisioner(:openshift) do


### PR DESCRIPTION
adds the commands sync-origin-aggregated-logging and
test-origin-aggregated-logging, and adds support for a
`--repo origin-aggregated-logging` argument to origin-local-checkout
and a couple of other commands.