### PR TITLE
Fix the --image-registry arg to test-origin

### DIFF
--- a/lib/vagrant-openshift/command/test_origin.rb
+++ b/lib/vagrant-openshift/command/test_origin.rb
@@ -71,7 +71,7 @@ module Vagrant
               options[:parallel] = true
             end
 
-            o.on("-r","--image-registry", String, "Image registry to configure tests with") do |f|
+            o.on("-r","--image-registry REGISTRY", String, "Image registry to configure tests with") do |f|
               options[:image_registry] = f
             end
 


### PR DESCRIPTION
#372 neglected to include a word in the argument specification that would allow a registry argument to be provided.