### PR TITLE
Checkout branch merged by GitHub

### DIFF
--- a/lib/vagrant-openshift/command/test_origin_image.rb
+++ b/lib/vagrant-openshift/command/test_origin_image.rb
@@ -121,11 +121,11 @@ cd $temp_dir
 git clone "#{source}"
 cd "#{source_dir}"
 
-# fetch the pull request's branch
-git fetch origin "pull/#{ref}/head:#{ref}"
+# GitHub automatically merges a PR with master, fetch that branch
+git fetch origin "pull/#{ref}/merge:#{ref}"
 
-# merge PR with master
-git merge --no-ff --no-edit "#{ref}"
+# checkout the PR merged with master
+git checkout "#{ref}"
 
 if [ "#{base_images}" == "true" -a -n "#{registry}" ]; then
   # Pull base images


### PR DESCRIPTION
Accidentally discovered we could do it better ;)

I saw this in the Jenkins log:

```
...
git rev-parse refs/remotes/origin/pr/124/merge^{commit} # timeout=10
...
```
https://ci.openshift.redhat.com/jenkins/job/mongodb/212/console

Which made me realize we don't need to use the `{PR_number}/head`, but instead we can fetch and use `{PR_number}/merge` so we don't need to do the merge ourselves.