### PR TITLE
Pass OPENSHIFT_TEST_IMAGE_REGISTRY to extended tests

### DIFF
--- a/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
@@ -195,6 +195,7 @@ usermod -a -G docker #{ssh_user}
 
 sed -i "s,^OPTIONS='\\(.*\\)',OPTIONS='--insecure-registry=172.30.0.0/16 \\1'," /etc/sysconfig/docker
 sed -i "s,^OPTIONS=-\\(.*\\),OPTIONS='--insecure-registry=172.30.0.0/16 -\\1'," /etc/sysconfig/docker
+sed -i "s,^OPTIONS=-\\(.*\\),OPTIONS='--insecure-registry=ci.dev.openshift.redhat.com:5000 -\\1'," /etc/sysconfig/docker
 sed -i "s,^ADD_REGISTRY='\\(.*\\)',#ADD_REGISTRY='--add-registry=docker.io \\1'," /etc/sysconfig/docker
 
 cat /etc/sysconfig/docker


### PR DESCRIPTION
Also, stop passing it to the non-extended tests, since only the extended
tests should be interacting with an external registry.