### PR TITLE
Create logical volume for openshift tests.

### DIFF
--- a/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
@@ -215,6 +215,12 @@ then
   sudo lvcreate -n docker-data -l 90%FREE /dev/${VG}
   sudo lvcreate -n docker-metadata -l 50%FREE /dev/${VG}
   sudo sed -i "s,^DOCKER_STORAGE_OPTIONS=.*,DOCKER_STORAGE_OPTIONS='-s devicemapper --storage-opt dm.datadev=/dev/${VG}/docker-data --storage-opt dm.metadatadev=/dev/${VG}/docker-metadata'," /etc/sysconfig/docker-storage
+
+  sudo lvcreate -n openshift-xfs-vol-dir -l 100%FREE /dev/${VG}
+  sudo mkfs.xfs /dev/${VG}/openshift-xfs-vol-dir
+  sudo mkdir -p /tmp/openshift/xfs-vol-dir
+  sudo sh -c "echo /dev/${VG}/openshift-xfs-vol-dir /tmp/openshift/xfs-vol-dir xfs gquota 1 1 >> /etc/fstab"
+  sudo mount /tmp/openshift/xfs-vol-dir
 fi
 
 # Force socket reuse


### PR DESCRIPTION
Incoming extended tests will require an XFS filesystem mounted with gquota to
pass. Create a partition for /tmp/openshift where test data lands, including
the volume directory.