### PR TITLE
Fix permissions on /tmp/openshift.

### DIFF
--- a/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
@@ -222,6 +222,7 @@ then
   sudo mkdir -p /tmp/openshift/xfs-vol-dir
   sudo sh -c "echo /dev/${VG}/openshift-xfs-vol-dir /tmp/openshift/xfs-vol-dir xfs gquota 1 1 >> /etc/fstab"
   sudo mount /tmp/openshift/xfs-vol-dir
+  sudo chown -R #{ssh_user}:#{ssh_user} /tmp/openshift
 fi
 
 # Force socket reuse


### PR DESCRIPTION
Because we're now creating this structure here, we need to make sure the
ssh_user can still work within it.

Assuming tests run as ssh_user this should work. After a test run of build-origin-base:

```
$ vagrant ssh
Last login: Sat Mar  5 20:00:10 2016 from cpe-107-15-149-49.nc.res.rr.com
[centos@ip-172-18-15-171 ~]$ ll /tmp
total 2236
-rw-r--r--. 1 root   root   2278361 Jun  8  2015 chromedriver_linux64.zip
drwxr-xr-x. 2 root   root        17 Mar 10 13:24 hsperfdata_root
-rw-r--r--. 1 root   root      1745 Nov  6  2008 linux_signing_key.pub
drwxr-xr-x. 3 centos centos      24 Mar 10 13:26 openshift
-rwx--x--x. 1 centos centos     459 Mar 10 13:20 vagrant-shell
[centos@ip-172-18-15-171 ~]$ ll /tmp/openshift
total 0
drwxr-xr-x. 2 centos centos 6 Mar 10 13:26 xfs-vol-dir
[centos@ip-172-18-15-171 ~]$ ll /tmp/openshift/xfs-vol-dir/
total 0
[centos@ip-172-18-15-171 ~]$ cd /tmp/openshift/
[centos@ip-172-18-15-171 openshift]$ ls
xfs-vol-dir
[centos@ip-172-18-15-171 openshift]$ touch hello.txt
[centos@ip-172-18-15-171 openshift]$ cd xfs-vol-dir/
[centos@ip-172-18-15-171 xfs-vol-dir]$ touch hello.txt
[centos@ip-172-18-15-171 xfs-vol-dir]$ ls
hello.txt
[centos@ip-172-18-15-171 xfs-vol-dir]$ echo "HI" > hello.txt 
[centos@ip-172-18-15-171 xfs-vol-dir]$ 
```