### PR TITLE
Move XFS volume dir to /mnt.

### DIFF
--- a/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
@@ -219,10 +219,10 @@ then
 
   sudo lvcreate -n openshift-xfs-vol-dir -l 100%FREE /dev/${VG}
   sudo mkfs.xfs /dev/${VG}/openshift-xfs-vol-dir
-  sudo mkdir -p /tmp/openshift/xfs-vol-dir
-  sudo sh -c "echo /dev/${VG}/openshift-xfs-vol-dir /tmp/openshift/xfs-vol-dir xfs gquota 1 1 >> /etc/fstab"
-  sudo mount /tmp/openshift/xfs-vol-dir
-  sudo chown -R #{ssh_user}:#{ssh_user} /tmp/openshift
+  sudo mkdir -p /mnt/openshift-xfs-vol-dir
+  sudo sh -c "echo /dev/${VG}/openshift-xfs-vol-dir /mnt/openshift-xfs-vol-dir xfs gquota 1 1 >> /etc/fstab"
+  sudo mount /mnt/openshift-xfs-vol-dir
+  sudo chown -R #{ssh_user}:#{ssh_user} /mnt/openshift-xfs-vol-dir
 fi
 
 # Force socket reuse


### PR DESCRIPTION
Previous location (/tmp/openshift/xfs-vol-dir) was being hidden by some element
of the test scripts that later mounts /tmp to a tmpfs.

Move to a separate location out of that tree and chown to the correct user.

Tested in EC2 and looks good.