### PR TITLE
make downloading release artifacts optional

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -197,7 +197,7 @@ module Vagrant
 
       def self.download_origin_artifacts(options)
         Vagrant::Action::Builder.new.tap do |b|
-          b.use DownloadArtifactsOrigin
+          b.use DownloadArtifactsOrigin, options
         end
       end
 

--- a/lib/vagrant-openshift/action/download_artifacts_origin.rb
+++ b/lib/vagrant-openshift/action/download_artifacts_origin.rb
@@ -21,9 +21,10 @@ module Vagrant
       class DownloadArtifactsOrigin
         include CommandHelper
 
-        def initialize(app, env)
+        def initialize(app, env, options)
           @app = app
           @env = env
+          @options = options.clone
         end
 
         def call(env)
@@ -39,9 +40,12 @@ module Vagrant
             "/var/log/audit/audit.log"       => artifacts_dir + "audit.log",
             "/tmp/openshift/"                => artifacts_dir,
 
-            "/data/src/github.com/openshift/origin/_output/local/releases/" => artifacts_dir + "release/",
             "/data/src/github.com/openshift/origin/assets/test/tmp/screenshots/" => artifacts_dir + "screenshots/"
           }
+
+          if @options[:download_release]
+            download_map["/data/src/github.com/openshift/origin/_output/local/releases/"] = artifacts_dir + "release/"
+          end
 
           download_map.each do |source,target|
             if ! machine.communicate.test("sudo ls #{source}")

--- a/lib/vagrant-openshift/command/download_artifacts_origin.rb
+++ b/lib/vagrant-openshift/command/download_artifacts_origin.rb
@@ -31,6 +31,10 @@ module Vagrant
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant download-artifacts-origin [machine-name]"
             o.separator ""
+
+            o.on("", "--include-release-artifacts", String, "Include release binaries") do |f|
+              options[:download_release] = true
+            end
           end
 
           # Parse the options

--- a/lib/vagrant-openshift/command/test_origin.rb
+++ b/lib/vagrant-openshift/command/test_origin.rb
@@ -59,6 +59,10 @@ module Vagrant
               options[:download] = true
             end
 
+            o.on("", "--download-release-artifacts", String, "Download release binaries") do |f|
+              options[:download_release] = true
+            end
+
             o.on("-s","--skip-image-cleanup", String, "Skip Docker image teardown for E2E test") do |f|
               options[:skip_image_cleanup] = true
             end


### PR DESCRIPTION
Adds new flags to Origin tests and artifact download to make release artifact download optional.

@bparees PTAL
@danmcp FYI

Thoughts on making this seamless - no AMI build missing artifacts? Should we just time this update correctly? Or should there be a pull first that allows the new flags but does nothing, so we can update the Jenkins job to use the flags, then push out this change to make the flag necessary to download artifacts?