### PR TITLE
origin-init: add option to check for AWS tag(s)

### DIFF
--- a/lib/vagrant-openshift/action/generate_template.rb
+++ b/lib/vagrant-openshift/action/generate_template.rb
@@ -122,8 +122,9 @@ module Vagrant
 
             aws_compute = Fog::Compute.new(fog_config)
             @env[:ui].info("Searching for latest base AMI")
-            images = aws_compute.images.all({'Owner' => 'self', 'name' => "#{box_info[:aws][:ami_tag_prefix]}*",
-                                             'state' => 'available' })
+            image_filter = {'Owner' => 'self', 'name' => "#{box_info[:aws][:ami_tag_prefix]}*", 'state' => 'available' }
+            image_filter['tag:Name'] = @options[:required_name_tag] unless @options[:required_name_tag].nil?
+            images = aws_compute.images.all(image_filter)
             latest_image = images.sort_by{ |i| i.name.split("_")[-1].to_i }.last
             box_info[:aws][:ami] = latest_image.id
             @env[:ui].info("Found: #{latest_image.id} (#{latest_image.name})")

--- a/lib/vagrant-openshift/command/origin_init.rb
+++ b/lib/vagrant-openshift/command/origin_init.rb
@@ -34,7 +34,8 @@ module Vagrant
             :volume_size => 25,
             :port_mappings => [],
             :no_synced_folders => false,
-            :no_insert_key => false
+            :no_insert_key => false,
+            :required_name_tag => nil
           }
 
           valid_stage = ['os','deps','inst']
@@ -70,6 +71,11 @@ module Vagrant
 
             o.on('--volume-size', "--volume-size [size]", String, "Specify the volume size for the instance") do |f|
               options[:volume_size] = f.to_i
+            end
+
+            o.on("--required-name-tag [name]", String, "Specify name tag to match against images, if supported") do |f|
+              name_tag = f.strip
+              options[:required_name_tag] = name_tag unless name_tag.empty?
             end
           end
 


### PR DESCRIPTION
This adds the `--required-tags` option to `origin-init`, which allows
callers to add one or more AWS tags for matching when selecting template
images.