### PR TITLE
Update epel-release version

### DIFF
--- a/lib/vagrant-openshift/action/create_yum_repositories.rb
+++ b/lib/vagrant-openshift/action/create_yum_repositories.rb
@@ -55,7 +55,7 @@ module Vagrant
 
           unless is_fedora
             unless env[:machine].communicate.test("rpm -q epel-release")
-              sudo(env[:machine], "yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm")
+              sudo(env[:machine], "yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm")
 
               #Workaround broken RHEL image which does not recover after restart.
               if "VagrantPlugins::AWS::Provider" == env[:machine].provider.class.to_s


### PR DESCRIPTION
`epel-release-7-5.noarch.rpm` is no longer available from the EPEL repos, it's been replaced with `epel-release-7-6.noarch.rpm`. non-Fedora base AMI builds will fail until this is updated.