### PR TITLE
Remove any existing vagrant artifacts when reusing git repo

### DIFF
--- a/lib/vagrant-openshift/helper/command_helper.rb
+++ b/lib/vagrant-openshift/helper/command_helper.rb
@@ -143,7 +143,7 @@ echo 'Replacing: #{repo_path}'
 pushd #{repo_path}
   git fetch origin
   git reset --hard origin/master
-  git clean -f
+  git clean -fdx
   set +e
   git branch | grep -ve " master$" | xargs git branch -D
   set -e


### PR DESCRIPTION
@jwforres found failures in the merge queue were caused by reusing old vagrant instances already marked as _terminate

This removes directories (-d) and untracked files (-x) to get the repo back to a pristine state