### PR TITLE
Pull in openshift-rhel7-dependencies for Go 1.6

### DIFF
--- a/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
@@ -131,6 +131,8 @@ chown root /usr/bin/chromedriver
 chmod 755 /usr/bin/chromedriver
           }, :timeout=>60*60, :verbose => false)
 
+          sudo(env[:machine], "wget -O /etc/yum.repos.d/openshift-rhel7-dependencies.repo https://mirror.openshift.com/pub/openshift-origin/nightly/rhel-7/dependencies/openshift-rhel7-dependencies.repo", fail_on_error: true, :timeout=>60*20, :verbose => true)
+
           #
           # FIXME: Need to install golang packages 'after' the 'gcc' is
           #        installed. See BZ#1101508


### PR DESCRIPTION
@danmcp this adds the repo for the rhel7 Go 1.6 build (targeted for 7.3) so that Centos7 and Fedora 23/24 can use it in Origin.

Manually tested on all 3 OS's, no problems hit.