### PR TITLE
Muted SSH exit status errors on test commands

### DIFF
--- a/lib/vagrant-openshift/helper/command_helper.rb
+++ b/lib/vagrant-openshift/helper/command_helper.rb
@@ -50,6 +50,14 @@ module Vagrant
           end
         }
 
+        # if verbose output is requested, we don't mess with vagrant's built-in SSH error handling
+        # otherwise, we ask for muted SSH error handling to reduce the clutter
+        if options[:verbose]
+          opts = nil
+        else
+          opts = { :error_key => :ssh_bad_exit_status_muted }
+        end
+
         (0..options[:retries]).each do |retry_count|
           begin
             if options[:verbose]
@@ -59,9 +67,9 @@ module Vagrant
             end
             Timeout::timeout(options[:timeout]) do
               if options[:sudo]
-                rc = machine.communicate.sudo(command, nil, &execute)
+                rc = machine.communicate.sudo(command, opts, &execute)
               else
-                rc = machine.communicate.execute(command, nil, &execute)
+                rc = machine.communicate.execute(command, opts, &execute)
               end
             end
           rescue Timeout::Error


### PR DESCRIPTION
In order to mangle the output of test scripts less,
all test calls to machine.communicator.{sudo,execute}
now pass :error_key => :ssh_bad_exit_status_muted, so
the errors that are printed by Vagrant do not contain
the command that was run, stderr, or stdout. The test
commands we are running will report this information
themselves by using the Origin stacktrace functions.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@danmcp PTAL

Fixes #461 