### PR TITLE
Configure `build-origin-base` to use local scripts

### DIFF
--- a/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
@@ -26,297 +26,46 @@ module Vagrant
         end
 
         def call(env)
-          # Workaround to vagrant inability to guess interface naming sequence
-          # Tell system to abandon the new naming scheme and use eth* instead
-          is_fedora = env[:machine].communicate.test("test -e /etc/fedora-release")
-          if is_fedora
-            sudo(env[:machine], %{
-if ! [[ -L /etc/udev/rules.d/80-net-setup-link.rules ]]; then
-  ln -s /dev/null /etc/udev/rules.d/80-net-setup-link.rules
-  rm -f /etc/sysconfig/network-scripts/ifcfg-enp0s3
-fi
-            }, :verbose => false)
-          end
+          # Migrate all of our scripts to the host machine
+          ssh_user = @env[:machine].ssh_info[:username]
+          destination="/home/#{ssh_user}/"
+          @env[:machine].communicate.upload(File.join(__dir__,"/../resources"), destination)
+          home="#{destination}/resources"
 
+          # Workaround to vagrant inability to guess interface naming sequence:
+          # Tell system to abandon the new naming scheme and use eth* instead if
+          # we're communicating with a Fedora machine
+          sudo(@env[:machine], "#{home}/reconfigure_network_fedora.sh")
 
-          sudo(env[:machine], %{
-if [[ -e /etc/redhat-release && ! -e /etc/fedora-release && ! -e /etc/centos-release ]]; then
+          # Install base dependencies that we cannot continue without
+          sudo(@env[:machine], "#{home}/install_dependencies.sh", :timeout=>60*30)
 
-cat <<EOF > /etc/yum.repos.d/dockerextra.repo
-[dockerextra]
-name=RHEL Docker Extra
-baseurl=https://mirror.openshift.com/enterprise/rhel/dockerextra/x86_64/os/
-enabled=1
-gpgcheck=0
-failovermethod=priority
-sslverify=False
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
-
-EOF
-
-fi
-          }, :timeout=>60*10, :verbose => false)
-
-          ssh_user = env[:machine].ssh_info[:username]
-          sudo(env[:machine], "yum install -y \
-                                augeas \
-                                bsdtar \
-                                bzr \
-                                bridge-utils \
-                                bzip2 \
-                                bind \
-                                btrfs-progs-devel \
-                                bind-utils \
-                                ctags \
-                                device-mapper-devel \
-                                docker-io \
-                                ethtool \
-                                e2fsprogs \
-                                fontconfig \
-                                git \
-                                gcc \
-                                gcc-c++ \
-                                glibc-static \
-                                gnuplot \
-                                httpie \
-                                hg \
-                                iscsi-initiator-utils \
-                                jq \
-                                java-1.?.0-openjdk \
-                                kernel-devel \
-                                krb5-devel \
-                                libselinux-devel \
-                                libnetfilter_queue-devel \
-                                lsof \
-                                make \
-                                mlocate \
-                                ntp \
-                                openldap-clients \
-                                openvswitch \
-                                rubygems \
-                                screen \
-                                ShellCheck \
-                                socat \
-                                sqlite-devel \
-                                strace \
-                                sysstat \
-                                tcpdump \
-                                tig \
-                                tmux \
-                                unzip \
-                                zip \
-                                vim \
-                                wget \
-                                xfsprogs \
-                                xorg-x11-utils \
-                                Xvfb \
-                                firefox \
-                                yum-utils",:timeout=>60*30, :verbose => false)
-
-          sudo(env[:machine], "yum install -y facter", fail_on_error: false, :timeout=>60*20, :verbose => false)
+          # Install dependencies that are nice to have but we can live without
+          sudo(@env[:machine], "#{home}/install_nonessential.sh", :timeout=>60*20, fail_on_error: false)
 
           # Install Chrome and chromedriver for headless UI testing
-          sudo(env[:machine], %{
-set -ex
-cd /tmp
-
-# Add signing key for Chrome repo
-wget https://dl.google.com/linux/linux_signing_key.pub
-rpm --import linux_signing_key.pub
-
-# Add Chrome yum repo
-yum-config-manager --add-repo=http://dl.google.com/linux/chrome/rpm/stable/x86_64
-
-# Install chrome
-yum install -y google-chrome-stable
-
-# Install chromedriver
-wget https://chromedriver.storage.googleapis.com/2.16/chromedriver_linux64.zip
-unzip chromedriver_linux64.zip
-mv chromedriver /usr/bin/chromedriver
-chown root /usr/bin/chromedriver
-chmod 755 /usr/bin/chromedriver
-          }, :timeout=>60*60, :verbose => false)
+          sudo(@env[:machine], "#{home}/install_chrome.sh", :timeout=>60*60)
 
           sudo(env[:machine], "wget -O /etc/yum.repos.d/openshift-rhel7-dependencies.repo https://mirror.openshift.com/pub/openshift-origin/nightly/rhel-7/dependencies/openshift-rhel7-dependencies.repo", fail_on_error: true, :timeout=>60*20, :verbose => true)
 
-          #
-          # FIXME: Need to install golang packages 'after' the 'gcc' is
-          #        installed. See BZ#1101508
-          #
-          sudo(env[:machine], "yum install -y golang golang-src", :timeout=>60*20, :verbose => false)
-          #
+          # Install Golang
+          sudo(@env[:machine], "#{home}/install_golang.sh", :timeout=>60*60)
 
-          unless is_fedora
-            sudo(env[:machine], "yum install -y golang-pkg-linux-amd64", :timeout=>60*20, :verbose => false)
+          # If we're on RHEL, install the RPM repositories for OSE and Docker
+          is_rhel = @env[:machine].communicate.test("test -e /etc/redhat-release && ! test -e /etc/fedora-release && ! test -e /etc/centos-release")
+          if is_rhel
+            sudo(@env[:machine], "#{home}/install_rhaos_repos.sh")
+            sudo(@env[:machine], "#{home}/install_dockerextra_repo.sh")
           end
 
-          sudo(env[:machine], %{
-set -ex
+          # Install Docker
+          sudo(@env[:machine], "yum install -y docker", :timeout=>60*60)
 
-if [[ -e /etc/redhat-release && ! -e /etc/fedora-release && ! -e /etc/centos-release ]]; then
+          # Configure the machine system and the Docker daemon
+          sudo(@env[:machine], "SSH_USER='#{ssh_user}' #{home}/configure_system.sh", :timeout=>60*30)
+          sudo(@env[:machine], "SSH_USER='#{ssh_user}' #{home}/configure_docker.sh", :timeout=>60*30)
 
-# create rhaos3.1 and 3.2 repos
-cat <<EOF > /etc/yum.repos.d/rhaos31.repo
-[rhel-7-server-ose-3.1-rpms]
-name=RHEL7 Red Hat Atomic OpenShift 3.1
-baseurl=https://mirror.ops.rhcloud.com/enterprise/enterprise-3.1/RH7-RHAOS-3.1/x86_64/os/
-        https://use-mirror1.ops.rhcloud.com/enterprise/enterprise-3.1/RH7-RHAOS-3.1/x86_64/os/
-        https://use-mirror2.ops.rhcloud.com/enterprise/enterprise-3.1/RH7-RHAOS-3.1/x86_64/os/
-        https://euw-mirror1.ops.rhcloud.com/enterprise/enterprise-3.1/RH7-RHAOS-3.1/x86_64/os/
-enabled=1
-gpgcheck=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-failovermethod=priority
-sslverify=0
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
-
-EOF
-
-
-cat <<EOF > /etc/yum.repos.d/rhaos32.repo
-[rhel-7-server-ose-3.2-rpms]
-name=RHEL7 Red Hat Atomic OpenShift 3.2
-baseurl=https://mirror.ops.rhcloud.com/enterprise/enterprise-3.2/latest/RH7-RHAOS-3.2/x86_64/os/
-        https://use-mirror1.ops.rhcloud.com/enterprise/enterprise-3.2/latest/RH7-RHAOS-3.2/x86_64/os/
-        https://use-mirror2.ops.rhcloud.com/enterprise/enterprise-3.2/latest/RH7-RHAOS-3.2/x86_64/os/
-        https://euw-mirror1.ops.rhcloud.com/enterprise/enterprise-3.2/latest/RH7-RHAOS-3.2/x86_64/os/
-enabled=1
-gpgcheck=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-failovermethod=priority
-sslverify=0
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
-
-EOF
-
-cat <<EOF > /etc/yum.repos.d/rhaos33.repo
-[rhel-7-server-ose-3.3-rpms]
-name=RHEL7 Red Hat Atomic OpenShift 3.3
-baseurl=https://mirror.ops.rhcloud.com/enterprise/enterprise-3.3/latest/RH7-RHAOS-3.3/x86_64/os/
-        https://use-mirror1.ops.rhcloud.com/enterprise/enterprise-3.3/latest/RH7-RHAOS-3.3/x86_64/os/
-        https://use-mirror2.ops.rhcloud.com/enterprise/enterprise-3.3/latest/RH7-RHAOS-3.3/x86_64/os/
-        https://euw-mirror1.ops.rhcloud.com/enterprise/enterprise-3.3/latest/RH7-RHAOS-3.3/x86_64/os/
-enabled=1
-gpgcheck=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-failovermethod=priority
-sslverify=0
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
-
-EOF
-
-cat <<EOF > /etc/yum.repos.d/rhaos34.repo
-[rhel-7-server-ose-3.4-rpms]
-name=RHEL7 Red Hat Atomic OpenShift 3.4
-baseurl=https://mirror.ops.rhcloud.com/enterprise/enterprise-3.4/latest/RH7-RHAOS-3.4/x86_64/os/
-        https://use-mirror1.ops.rhcloud.com/enterprise/enterprise-3.4/latest/RH7-RHAOS-3.4/x86_64/os/
-        https://use-mirror2.ops.rhcloud.com/enterprise/enterprise-3.4/latest/RH7-RHAOS-3.4/x86_64/os/
-        https://euw-mirror1.ops.rhcloud.com/enterprise/enterprise-3.4/latest/RH7-RHAOS-3.4/x86_64/os/
-enabled=1
-gpgcheck=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
-failovermethod=priority
-sslverify=0
-sslclientcert=/var/lib/yum/client-cert.pem
-sslclientkey=/var/lib/yum/client-key.pem
-
-EOF
-
-fi
-
-if ! test -e /etc/fedora-release; then
-  sed -i 's,^SELINUX=.*,SELINUX=permissive,' /etc/selinux/config
-  setenforce 0
-fi
-
-systemctl enable ntpd
-
-groupadd -f docker
-usermod -a -G docker #{ssh_user}
-
-ADDITIONAL_OPTIONS='--insecure-registry=172.30.0.0/16 --insecure-registry=ci.dev.openshift.redhat.com:5000'
-sed -i "s,^OPTIONS='\\(.*\\)',OPTIONS='${ADDITIONAL_OPTIONS} \\1'," /etc/sysconfig/docker
-sed -i "s,^OPTIONS=-\\(.*\\),OPTIONS='${ADDITIONAL_OPTIONS} -\\1'," /etc/sysconfig/docker
-sed -i "s,^ADD_REGISTRY='\\(.*\\)',#ADD_REGISTRY='--add-registry=docker.io \\1'," /etc/sysconfig/docker
-
-cat /etc/sysconfig/docker
-
-
-if sudo lvdisplay docker-vg 2>&1>/dev/null
-then
-  VG="docker-vg"
-elif sudo lvdisplay vg_vagrant 2>&1>/dev/null
-then
-  VG="vg_vagrant"
-elif sudo lvdisplay fedora 2>&1>/dev/null
-then
-  VG="fedora"
-elif sudo lvdisplay centos 2>&1>/dev/null
-then
-  VG="centos"
-fi
-if [ -n "${VG}" ]
-then
-  sudo lvcreate -n docker-data -l 70%FREE /dev/${VG}
-  sudo lvcreate -n docker-metadata -l 17%FREE /dev/${VG}
-  sudo sed -i "s,^DOCKER_STORAGE_OPTIONS=.*,DOCKER_STORAGE_OPTIONS='-s devicemapper --storage-opt dm.datadev=/dev/${VG}/docker-data --storage-opt dm.metadatadev=/dev/${VG}/docker-metadata --storage-opt dm.use_deferred_removal=true --storage-opt dm.use_deferred_deletion=true'," /etc/sysconfig/docker-storage
-
-  sudo lvcreate -n openshift-xfs-vol-dir -l 100%FREE /dev/${VG}
-  sudo mkfs.xfs /dev/${VG}/openshift-xfs-vol-dir
-  sudo mkdir -p /mnt/openshift-xfs-vol-dir
-  sudo sh -c "echo /dev/${VG}/openshift-xfs-vol-dir /mnt/openshift-xfs-vol-dir xfs gquota 1 1 >> /etc/fstab"
-  sudo mount /mnt/openshift-xfs-vol-dir
-  sudo chown -R #{ssh_user}:#{ssh_user} /mnt/openshift-xfs-vol-dir
-fi
-
-# Force socket reuse
-echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
-
-mkdir -p /data/src
-mkdir -p /data/pkg
-mkdir -p /data/bin
-
-GO_VERSION=($(go version))
-echo "Detected go version: $(go version)"
-
-# TODO: Remove for go1.5, go vet and go cover will be internal
-if [[ ${GO_VERSION[2]} == "go1.4"* ]]; then
-  GOPATH=/data go get golang.org/x/tools/cmd/cover
-
-# https://groups.google.com/forum/#!topic/golang-nuts/nZLhcbaa3wQ
-set +e
-  GOPATH=/data go get golang.org/x/tools/cmd/vet
-set -e
-
-  # Check out a stable commit for go vet in order to version lock it to something we can work with
-  pushd /data/src/golang.org/x/tools >/dev/null
-    if git checkout 108746816ddf01ad0c2dbea08a1baef08bc47313
-    then
-      # Re-install using this version of the tool
-      GOPATH=/data go install golang.org/x/tools/cmd/vet
-    fi
-  popd >/dev/null
-fi
-
-chown -R #{ssh_user}:#{ssh_user} /data
-
-sed -i "s,^#DefaultTimeoutStartSec=.*,DefaultTimeoutStartSec=240s," /etc/systemd/system.conf
-
-# Docker 1.8.2 now sets a TimeoutStartSec of 1 minute.  Unfortunately, for some
-# reason the initial docker start up is now taking > 5 minutes.  Until that is fixed need this.
-sed -i 's,TimeoutStartSec=.*,TimeoutStartSec=10min,'  /usr/lib/systemd/system/docker.service
-
-systemctl daemon-reexec
-systemctl daemon-reload
-systemctl enable docker
-time systemctl start docker
-          }, :timeout=>60*30, :verbose => false)
-          @app.call(env)
+          @app.call(@env)
         end
       end
     end

--- a/lib/vagrant-openshift/resources/configure_docker.sh
+++ b/lib/vagrant-openshift/resources/configure_docker.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+groupadd -f docker
+usermod -a -G docker "${SSH_USER}"
+
+ADDITIONAL_OPTIONS='--insecure-registry=172.30.0.0/16 --insecure-registry=ci.dev.openshift.redhat.com:5000'
+sed -i "s,^OPTIONS='\\(.*\\)',OPTIONS='${ADDITIONAL_OPTIONS} \\1'," /etc/sysconfig/docker
+sed -i "s,^OPTIONS=-\\(.*\\),OPTIONS='${ADDITIONAL_OPTIONS} -\\1'," /etc/sysconfig/docker
+sed -i "s,^ADD_REGISTRY='\\(.*\\)',#ADD_REGISTRY='--add-registry=docker.io \\1'," /etc/sysconfig/docker
+
+if lvdisplay docker-vg >/dev/null 2>&1; then
+    VG="docker-vg"
+elif lvdisplay vg_vagrant >/dev/null 2>&1; then
+    VG="vg_vagrant"
+elif lvdisplay fedora >/dev/null 2>&1; then
+    VG="fedora"
+elif lvdisplay centos >/dev/null 2>&1; then
+    VG="centos"
+fi
+
+if [[ -n "${VG}" ]]; then
+    lvcreate -n docker-data -l 70%FREE /dev/${VG}
+    lvcreate -n docker-metadata -l 17%FREE /dev/${VG}
+    DOCKER_STORAGE_OPTIONS="  -s devicemapper"
+    DOCKER_STORAGE_OPTIONS+=" --storage-opt dm.datadev=/dev/${VG}/docker-data"
+    DOCKER_STORAGE_OPTIONS+=" --storage-opt dm.metadatadev=/dev/${VG}/docker-metadata"
+    if [[ "$(repoquery --pkgnarrow=installed --qf '%{version}' docker)" =~ ^1\.[0-9]{2}\..* ]]; then
+        # after Docker 1.10 we need to amend the devicemapper options
+        DOCKER_STORAGE_OPTIONS+=" --storage-opt dm.use_deferred_removal=true"
+        DOCKER_STORAGE_OPTIONS+=" --storage-opt dm.use_deferred_deletion=true"
+    fi
+    sed -i "s,^DOCKER_STORAGE_OPTIONS=.*,DOCKER_STORAGE_OPTIONS='${DOCKER_STORAGE_OPTIONS}'," /etc/sysconfig/docker-storage
+
+    lvcreate -n openshift-xfs-vol-dir -l 100%FREE /dev/${VG}
+    mkfs.xfs /dev/${VG}/openshift-xfs-vol-dir
+    mkdir -p /mnt/openshift-xfs-vol-dir
+    echo /dev/${VG}/openshift-xfs-vol-dir /mnt/openshift-xfs-vol-dir xfs gquota 1 1 >> /etc/fstab
+    mount /mnt/openshift-xfs-vol-dir
+    chown -R "${SSH_USER}:${SSH_USER}" /mnt/openshift-xfs-vol-dir
+fi
+
+# Docker 1.8.2 now sets a TimeoutStartSec of 1 minute.  Unfortunately, for some
+# reason the initial docker start up is now taking > 5 minutes.  Until that is fixed need this.
+sed -i 's,TimeoutStartSec=.*,TimeoutStartSec=10min,'  /usr/lib/systemd/system/docker.service
+
+systemctl daemon-reexec
+systemctl daemon-reload
+systemctl enable docker
+time systemctl start docker

--- a/lib/vagrant-openshift/resources/configure_system.sh
+++ b/lib/vagrant-openshift/resources/configure_system.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ ! -e /etc/fedora-release ]]; then
+    sed -i 's,^SELINUX=.*,SELINUX=permissive,' /etc/selinux/config
+    setenforce 0
+fi
+
+systemctl enable ntpd
+
+# Force socket reuse
+echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
+
+mkdir -p /data/src
+mkdir -p /data/pkg
+mkdir -p /data/bin
+
+GO_VERSION=($(go version))
+echo "Detected go version: $(go version)"
+
+chown -R "${SSH_USER}:${SSH_USER}" /data
+
+sed -i "s,^#DefaultTimeoutStartSec=.*,DefaultTimeoutStartSec=240s," /etc/systemd/system.conf

--- a/lib/vagrant-openshift/resources/dockerextra.repo
+++ b/lib/vagrant-openshift/resources/dockerextra.repo
@@ -1,0 +1,9 @@
+[dockerextra]
+name=RHEL Docker Extra
+baseurl=https://mirror.openshift.com/enterprise/rhel/dockerextra/x86_64/os/
+enabled=1
+gpgcheck=0
+failovermethod=priority
+sslverify=False
+sslclientcert=/var/lib/yum/client-cert.pem
+sslclientkey=/var/lib/yum/client-key.pem

--- a/lib/vagrant-openshift/resources/install_chrome.sh
+++ b/lib/vagrant-openshift/resources/install_chrome.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -o errexit
+
+cd /tmp
+
+# Add signing key for Chrome repo
+wget https://dl.google.com/linux/linux_signing_key.pub
+rpm --import linux_signing_key.pub
+
+# Add Chrome yum repo
+yum-config-manager --add-repo=http://dl.google.com/linux/chrome/rpm/stable/x86_64
+
+# Install chrome
+yum install -y google-chrome-stable
+
+# Install chromedriver
+wget https://chromedriver.storage.googleapis.com/2.16/chromedriver_linux64.zip
+unzip chromedriver_linux64.zip
+mv chromedriver /usr/bin/chromedriver
+chown root /usr/bin/chromedriver
+chmod 755 /usr/bin/chromedriver

--- a/lib/vagrant-openshift/resources/install_dependencies.sh
+++ b/lib/vagrant-openshift/resources/install_dependencies.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -o errexit
+
+yum install -y                       \
+            augeas                   \
+            bzr                      \
+            bridge-utils             \
+            bzip2                    \
+            bind                     \
+            bsdtar                   \
+            btrfs-progs-devel        \
+            bind-utils               \
+            ctags                    \
+            device-mapper-devel      \
+            ethtool                  \
+            e2fsprogs                \
+            firefox                  \
+            fontconfig               \
+            git                      \
+            gcc                      \
+            gcc-c++                  \
+            glibc-static             \
+            gnuplot                  \
+            httpie                   \
+            hg                       \
+            iscsi-initiator-utils    \
+            jq                       \
+            java-1.?.0-openjdk       \
+            kernel-devel             \
+            krb5-devel               \
+            libselinux-devel         \
+            libnetfilter_queue-devel \
+            lsof                     \
+            make                     \
+            mlocate                  \
+            ntp                      \
+            openldap-clients         \
+            openvswitch              \
+            rubygems                 \
+            screen                   \
+            ShellCheck               \
+            socat                    \
+            sqlite-devel             \
+            strace                   \
+            sysstat                  \
+            tcpdump                  \
+            tig                      \
+            tmux                     \
+            unzip                    \
+            vim                      \
+            wget                     \
+            xfsprogs                 \
+            xorg-x11-utils           \
+            Xvfb                     \
+            yum-utils                \
+            zip

--- a/lib/vagrant-openshift/resources/install_dockerextra_repo.sh
+++ b/lib/vagrant-openshift/resources/install_dockerextra_repo.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o errexit
+
+# we depend on a version of Docker that's newer than the RPMS in
+# RHEL, so we need to install our own repository and install from
+# there
+if [[ -e /etc/redhat-release && ! -e /etc/fedora-release && ! -e /etc/centos-release ]]; then
+	mv "$(dirname "${BASH_SOURCE}")/dockerextra.repo" /etc/yum.repos.d/
+fi

--- a/lib/vagrant-openshift/resources/install_golang.sh
+++ b/lib/vagrant-openshift/resources/install_golang.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o errexit
+
+yum install -y golang
+
+if [[ ! -e /etc/fedora-release ]] && go version | grep -q 'go1\.4'; then
+    # Prior to go1.5, the cgo symbol tables were not provided in the base golang
+    # package on RHEL and CentOS, so if we've installed go1.4.x and we're not on
+    # Fedora, we need to also install `golang-pkg-linux-amd64'
+    yum install -y golang-pkg-linux-amd64
+fi

--- a/lib/vagrant-openshift/resources/install_nonessential.sh
+++ b/lib/vagrant-openshift/resources/install_nonessential.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -o errexit
+
+yum install -y     \
+            facter

--- a/lib/vagrant-openshift/resources/install_rhaos_repos.sh
+++ b/lib/vagrant-openshift/resources/install_rhaos_repos.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o errexit
+
+# on RHEL machines, if we're installing or using OSE, we will need the
+# following repositories in order to fetch OSE-specific RPMs
+
+mv "$(dirname "${BASH_SOURCE}")/rhaos31.repo" /etc/yum.repos.d/
+mv "$(dirname "${BASH_SOURCE}")/rhaos32.repo" /etc/yum.repos.d/

--- a/lib/vagrant-openshift/resources/origin-deps-rhel7.repo
+++ b/lib/vagrant-openshift/resources/origin-deps-rhel7.repo
@@ -1,0 +1,11 @@
+[origin-deps-rhel7]
+name=OpenShift Origin Dependency repo for RHEL 7
+baseurl=http://mirror.openshift.com/pub/openshift-origin/nightly/rhel-7/dependencies/x86_64/
+enabled=1
+gpgcheck=0
+
+[origin-deps-rhel7-source]
+name=OpenShift Origin Dependency repo for RHEL 7 SRPMS
+baseurl=http://mirror.openshift.com/pub/openshift-origin/nightly/rhel-7/dependencies/SRPMS/
+enabled=0
+gpgcheck=0

--- a/lib/vagrant-openshift/resources/reconfigure_network_fedora.sh
+++ b/lib/vagrant-openshift/resources/reconfigure_network_fedora.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+
+if [[ -e /etc/fedora-release ]]; then
+    if [[ ! -L /etc/udev/rules.d/80-net-setup-link.rules ]]; then
+        # If it's not already done, we need to enforce the older eth* naming
+        # sequence on Fedora machines as Vagrant isn't compatible with the
+        # systemd197 name changes.
+        ln -s /dev/null /etc/udev/rules.d/80-net-setup-link.rules
+        rm -f /etc/sysconfig/network-scripts/ifcfg-enp0s3
+    fi
+fi

--- a/lib/vagrant-openshift/resources/rhaos31.repo
+++ b/lib/vagrant-openshift/resources/rhaos31.repo
@@ -1,0 +1,13 @@
+[rhel-7-server-ose-3.1-rpms]
+name=RHEL7 Red Hat Atomic OpenShift 3.1
+baseurl=https://mirror.ops.rhcloud.com/enterprise/enterprise-3.1/RH7-RHAOS-3.1/x86_64/os/
+        https://use-mirror1.ops.rhcloud.com/enterprise/enterprise-3.1/RH7-RHAOS-3.1/x86_64/os/
+        https://use-mirror2.ops.rhcloud.com/enterprise/enterprise-3.1/RH7-RHAOS-3.1/x86_64/os/
+        https://euw-mirror1.ops.rhcloud.com/enterprise/enterprise-3.1/RH7-RHAOS-3.1/x86_64/os/
+enabled=1
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+failovermethod=priority
+sslverify=0
+sslclientcert=/var/lib/yum/client-cert.pem
+sslclientkey=/var/lib/yum/client-key.pem

--- a/lib/vagrant-openshift/resources/rhaos32.repo
+++ b/lib/vagrant-openshift/resources/rhaos32.repo
@@ -1,0 +1,13 @@
+[rhel-7-server-ose-3.2-rpms]
+name=RHEL7 Red Hat Atomic OpenShift 3.2
+baseurl=https://mirror.ops.rhcloud.com/enterprise/enterprise-3.2/latest/RH7-RHAOS-3.2/x86_64/os/
+        https://use-mirror1.ops.rhcloud.com/enterprise/enterprise-3.2/latest/RH7-RHAOS-3.2/x86_64/os/
+        https://use-mirror2.ops.rhcloud.com/enterprise/enterprise-3.2/latest/RH7-RHAOS-3.2/x86_64/os/
+        https://euw-mirror1.ops.rhcloud.com/enterprise/enterprise-3.2/latest/RH7-RHAOS-3.2/x86_64/os/
+enabled=1
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+failovermethod=priority
+sslverify=0
+sslclientcert=/var/lib/yum/client-cert.pem
+sslclientkey=/var/lib/yum/client-key.pem

--- a/lib/vagrant-openshift/resources/rhaos33.repo
+++ b/lib/vagrant-openshift/resources/rhaos33.repo
@@ -1,0 +1,13 @@
+[rhel-7-server-ose-3.3-rpms]
+name=RHEL7 Red Hat Atomic OpenShift 3.3
+baseurl=https://mirror.ops.rhcloud.com/enterprise/enterprise-3.3/latest/RH7-RHAOS-3.3/x86_64/os/
+        https://use-mirror1.ops.rhcloud.com/enterprise/enterprise-3.3/latest/RH7-RHAOS-3.3/x86_64/os/
+        https://use-mirror2.ops.rhcloud.com/enterprise/enterprise-3.3/latest/RH7-RHAOS-3.3/x86_64/os/
+        https://euw-mirror1.ops.rhcloud.com/enterprise/enterprise-3.3/latest/RH7-RHAOS-3.3/x86_64/os/
+enabled=1
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+failovermethod=priority
+sslverify=0
+sslclientcert=/var/lib/yum/client-cert.pem
+sslclientkey=/var/lib/yum/client-key.pem

--- a/lib/vagrant-openshift/resources/rhaos34.repo
+++ b/lib/vagrant-openshift/resources/rhaos34.repo
@@ -1,0 +1,13 @@
+[rhel-7-server-ose-3.4-rpms]
+name=RHEL7 Red Hat Atomic OpenShift 3.4
+baseurl=https://mirror.ops.rhcloud.com/enterprise/enterprise-3.4/latest/RH7-RHAOS-3.4/x86_64/os/
+        https://use-mirror1.ops.rhcloud.com/enterprise/enterprise-3.4/latest/RH7-RHAOS-3.4/x86_64/os/
+        https://use-mirror2.ops.rhcloud.com/enterprise/enterprise-3.4/latest/RH7-RHAOS-3.4/x86_64/os/
+        https://euw-mirror1.ops.rhcloud.com/enterprise/enterprise-3.4/latest/RH7-RHAOS-3.4/x86_64/os/
+enabled=1
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,https://mirror.ops.rhcloud.com/libra/keys/RPM-GPG-KEY-redhat-openshifthosted
+failovermethod=priority
+sslverify=0
+sslclientcert=/var/lib/yum/client-cert.pem
+sslclientkey=/var/lib/yum/client-key.pem


### PR DESCRIPTION
The code that supports `build-origin-base` was becoming unwieldy, so to
allow for easy modification and maintenance, it will be refactored to run
local scripts on the machine. The scripts are packaged with the plugin.

The first step of this command now is to copy all the available scripts
to the machine. The workflow for running scripts is shown in the refactor
of the network configuration script in this commit.

Signed-off-by: Steve Kuznetsov skuznets@redhat.com

@danmcp PTAL
