### PR TITLE
Update README.asciidoc

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -286,7 +286,7 @@ sudo alternatives --set ld /usr/bin/ld.gold
 
 [source, sh]
 ----
-sudo usermod -G -a libvirt $USER
+sudo usermod -a -G libvirt $USER
 ----
 
 * Log out and log in for the group change to take effect


### PR DESCRIPTION
usermod parameters were backward in libvirt section (order matters, -a -G instead of -G -a)