### PR TITLE
prune tags that no longer exist in origin

### DIFF
--- a/lib/vagrant-openshift/helper/command_helper.rb
+++ b/lib/vagrant-openshift/helper/command_helper.rb
@@ -152,6 +152,7 @@ set -e
 echo 'Replacing: #{repo_path}'
 pushd #{repo_path}
   git fetch origin
+  git fetch --prune origin +refs/tags/*:refs/tags/*
   git reset --merge
   git checkout #{branch}
   git reset --hard origin/#{branch}


### PR DESCRIPTION
cleans up local tags that no longer exist in the `origin` remote

needed to fix https://github.com/openshift/origin/issues/10795