### PR TITLE
updating usermod command syntax so that command does not fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+before_install:
+  - gem uninstall bundler -aIxq --force
+  - gem uninstall -Ixq --force -i /home/travis/.rvm/gems/ruby-2.2.3@global bundler
+  - gem install bundler -v '1.12.5'
+
 rvm:
   - 2.2.3
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,9 @@ group :development do
     gem "vagrant", path: "../vagrant"
   else
     if Gem::Version.new(Bundler::VERSION) < Gem::Version.new("1.12.5")
-      gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git", :ref => "v1.7.4"
+      gem "vagrant", :git => "https://github.com/mitchellh/vagrant", :ref => "v1.7.4"
     else
-      gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git"
+      gem "vagrant", :git => "https://github.com/mitchellh/vagrant"
     end
   end
   gem "json"

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -286,7 +286,7 @@ sudo alternatives --set ld /usr/bin/ld.gold
 
 [source, sh]
 ----
-sudo usermod -G -a libvirt $USER
+sudo usermod -a -G libvirt $USER
 ----
 
 * Log out and log in for the group change to take effect


### PR DESCRIPTION
Corrects the usermod command syntax, as it will fail with the following message:
`usermod: group '-a' does not exist`
The correct syntax should be `usermod -a -G libvirt $USER`

Replaces git:// with https:// in Gemfile 

Removed default version of bundler on travis-ci and replaces with 1.12.5 which is needed by the vagrant gem