### PR TITLE
add `--prune=all` to `git gc`

### DIFF
--- a/lib/vagrant-openshift/helper/command_helper.rb
+++ b/lib/vagrant-openshift/helper/command_helper.rb
@@ -166,7 +166,7 @@ then
         set +e
         git branch | grep -ve " #{branch}$" | xargs git branch -D
         set -e
-        git gc
+        git gc --prune=all
       popd
     else
       echo 'Already cloned: #{repo}'


### PR DESCRIPTION
`git gc` leaves 2 weeks of refs by default, but with a heavily-used repo
that means loads of "`dangling commit`" messages in the git fsck output.
Adding `--prune=all` cleans up all commits, so we should only get one or
a couple of dangling commits in the output on the next run.