### PR TITLE
Add `xrandr` dependency to allow headless tests to poll for their display

### DIFF
--- a/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
@@ -103,6 +103,7 @@ fi
                                 vim \
                                 wget \
                                 xfsprogs \
+                                xorg-x11-server-utils \
                                 Xvfb \
                                 firefox \
                                 yum-utils",:timeout=>60*30, :verbose => false)


### PR DESCRIPTION
@benjaminapetersen will use this in his `hack/test-headless.sh` work.

/cc @danmcp @jwforres 

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>