### PR TITLE
Install the X11 utilities instead of the X11 server utilities

### DIFF
--- a/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_origin_base_dependencies.rb
@@ -103,7 +103,7 @@ fi
                                 vim \
                                 wget \
                                 xfsprogs \
-                                xorg-x11-server-utils \
+                                xorg-x11-utils \
                                 Xvfb \
                                 firefox \
                                 yum-utils",:timeout=>60*30, :verbose => false)


### PR DESCRIPTION
When choosing a program to poll for readiness of a display, it
looks like `xdpyinfo` is superior to `xrandr` as it makes few
assumptions about the host and seems to be compatible with all
of the operating systems that we want to run web console tests
on in headless mode.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>