### PR TITLE
Use a headless server to run web console unit tests in dependency install

### DIFF
--- a/lib/vagrant-openshift/action/install_origin_asset_dependencies.rb
+++ b/lib/vagrant-openshift/action/install_origin_asset_dependencies.rb
@@ -66,7 +66,7 @@ popd
             cmd += %{
   # Make sure tests pass before backing up this asset install
   pushd $ORIGIN_CONSOLE_PATH
-    grunt test
+    hack/test-headless.sh test
   popd
   mkdir -p $ASSET_BACKUP_DIR
   cp -rf $ORIGIN_CONSOLE_PATH/node_modules $ASSET_BACKUP_DIR/node_modules


### PR DESCRIPTION

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>