### PR TITLE
Use a `make` target to run web console tests

### DIFF
--- a/lib/vagrant-openshift/action/run_origin_asset_tests.rb
+++ b/lib/vagrant-openshift/action/run_origin_asset_tests.rb
@@ -67,9 +67,7 @@ popd >/dev/null
             cmds += @options[:envs]
           end
 
-          cmds << 'hack/verify-dist.sh'
-          cmds << 'grunt test'
-          cmds << 'hack/test-integration-headless.sh'
+          cmds << 'make test -o build'
           cmd = cmds.join(' ')
           env[:test_exit_code] = run_tests(env, cmds, @options[:root])
 


### PR DESCRIPTION
Instead of assuming things about how the web console wants
to run their test suites, we should instead simply run their
appropriate `make` target and let the repository define that
in whatever way they want.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@spadgett @danmcp @jwforres