### PR TITLE
Allow for users to pass environment variables to extended tests

### DIFF
--- a/lib/vagrant-openshift/action/run_origin_tests.rb
+++ b/lib/vagrant-openshift/action/run_origin_tests.rb
@@ -116,6 +116,11 @@ popd >/dev/null
             if @options[:image_registry]
               extended_cmd_env << "OPENSHIFT_TEST_IMAGE_REGISTRY=#{@options[:image_registry]}"
             end
+
+            if @options[:envs]
+              extended_cmd_env += @options[:envs]
+            end
+
             extended_cmd_env_str = extended_cmd_env.join(' ')
 
             cmds = cmds.map{ |s| "#{extended_cmd_env_str} #{s}".strip }


### PR DESCRIPTION
In order for users to parameterize their extended test runs using
vagrant-openshift, we need to allow the `vagrant test-origin --env`
environment variables to be honored for all test runs, not just
the non-extended ones.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @gabemontero @jupierce 
@danmcp PTAL