### PR TITLE
Remove shell-word escaping from extended test execution code

### DIFF
--- a/lib/vagrant-openshift/action/run_origin_tests.rb
+++ b/lib/vagrant-openshift/action/run_origin_tests.rb
@@ -134,8 +134,8 @@ popd >/dev/null
           cmds = []
           buckets.each do |bucket|
             if bucket.include?('(')
-              focus = bucket.slice(bucket.index("(")+1..-2).split(" ").map { |i| Shellwords.escape(i.strip) }.join(" ")
-              name = Shellwords.escape(bucket.slice(0..bucket.index("(")-1))
+              focus = bucket.slice(bucket.index("(")+1..-2).split(" ").map { |i| i.strip }.join(" ")
+              name = bucket.slice(0..bucket.index("(")-1)
               cmds << "test/extended/#{name.strip}.sh --ginkgo.focus=\"#{focus}\""
             else
               cmds << "test/extended/#{Shellwords.escape(bucket.strip)}.sh"


### PR DESCRIPTION
A valid extended test bucket name should never contain any
special shell characters, so it is unnecessary to attempt
to escape them. Similarly, the only characters inside of a
focus string that we are vulnerable to are double-quotes.
Extended test focuses should not contain literal double
quotes, so we should not need to escape anything in those
either.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes https://github.com/openshift/vagrant-openshift/issues/476

@bparees @danmcp PTAL