### PR TITLE
Customer Diagnostics commands

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -187,6 +187,20 @@ module Vagrant
         end
       end
 
+      def self.repo_sync_customer_diagnostics(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use PrepareSshConfig
+          if options[:source]
+            if options[:clean]
+              b.use Clean, options
+              b.use CloneUpstreamRepositories, options
+            end
+            b.use SyncLocalRepository, options
+            b.use CheckoutRepositories, options
+          end
+        end
+      end
+
       def self.local_origin_checkout(options)
         Vagrant::Action::Builder.new.tap do |b|
           if not options[:no_build]
@@ -236,6 +250,17 @@ module Vagrant
           b.use TestExitCode
         end
       end
+
+      def self.run_customer_diagnostics_tests(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use RunCustomerDiagnosticsTests, options
+          if options[:download]
+            b.use DownloadArtifactsOriginMetrics
+          end
+          b.use TestExitCode
+        end
+      end
+
 
       def self.run_sti_tests(options)
         Vagrant::Action::Builder.new.tap do |b|
@@ -358,6 +383,7 @@ module Vagrant
       autoload :RunStiTests, action_root.join("run_sti_tests")
       autoload :RunOriginAggregatedLoggingTests, action_root.join("run_origin_aggregated_logging_tests")
       autoload :RunOriginMetricsTests, action_root.join("run_origin_metrics_tests")
+      autoload :RunCustomerDiagnosticsTests, action_root.join("run_customer_diagnostics_tests")
       autoload :GenerateTemplate, action_root.join("generate_template")
       autoload :CreateAMI, action_root.join("create_ami")
       autoload :ModifyInstance, action_root.join("modify_instance")

--- a/lib/vagrant-openshift/action/run_customer_diagnostics_tests.rb
+++ b/lib/vagrant-openshift/action/run_customer_diagnostics_tests.rb
@@ -1,0 +1,79 @@
+#--
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+module Vagrant
+  module Openshift
+    module Action
+      class RunCustomerDiagnosticsTests
+        include CommandHelper
+
+        @@SSH_TIMEOUT = 4800
+
+        def initialize(app, env, options)
+          @app = app
+          @env = env
+          @options = options.clone
+        end
+
+        def run_tests(env, cmds, as_root=true)
+          tests = ''
+          cmds.each do |cmd|
+            tests += "
+echo '***************************************************'
+echo 'Running #{cmd}...'
+time #{cmd}
+echo 'Finished #{cmd}'
+echo '***************************************************'
+"
+          end
+          cmd = %{
+set -e
+pushd #{Constants.build_dir}/openshift-ansible/ >/dev/null
+export PATH=$GOPATH/bin:$PATH
+#{tests}
+popd >/dev/null
+        }
+          exit_code = 0
+          if as_root
+            _,_,exit_code = sudo(env[:machine], cmd, {:timeout => 60*60*4, :fail_on_error => false, :verbose => false})
+          else
+            _,_,exit_code = do_execute(env[:machine], cmd, {:timeout => 60*60*4, :fail_on_error => false, :verbose => false})
+          end
+          exit_code
+        end
+
+        #
+        # All env vars will be added to the beginning of the command like VAR=1 make test
+        #
+        def call(env)
+          @options.delete :logs
+
+          cmd_env = []
+
+          if @options[:envs]
+            cmd_env += @options[:envs]
+          end
+
+          cmd_env << "make #{@options[:target]}"
+          cmd = cmd_env.join(' ')
+          env[:test_exit_code] = run_tests(env, [cmd], @options[:root])
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/command/repo_sync_customer_diagnostics.rb
+++ b/lib/vagrant-openshift/command/repo_sync_customer_diagnostics.rb
@@ -1,0 +1,71 @@
+#--
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require_relative "../action"
+
+module Vagrant
+  module Openshift
+    module Commands
+      class RepoSyncCustomerDiagnostics < Vagrant.plugin(2, :command)
+        include CommandHelper
+
+        def self.synopsis
+          "syncs your local repos to the current instance"
+        end
+
+        def execute
+          options = {}
+          options[:images] = true
+          options[:build] = true
+          options[:clean] = false
+          options[:source] = false
+          options[:repo] = 'openshift-ansible'
+
+          opts = OptionParser.new do |o|
+            o.banner = "Usage: vagrant sync-customer-diagnostics [vm-name]"
+            o.separator ""
+
+            o.on("-s", "--source", "Sync the source (not required if using synced folders)") do |f|
+              options[:source] = f
+            end
+
+            o.on("-c", "--clean", "Delete existing repo before syncing source") do |f|
+              options[:clean] = f
+            end
+
+            o.on("--dont-install", "Don't build and install updated source") do |f|
+              options[:build] = false
+            end
+
+            o.on("--no-images", "Don't build updated component Docker images") do |f|
+              options[:images] = false
+            end
+
+          end
+
+          # Parse the options
+          argv = parse_options(opts)
+          return if !argv
+
+          with_target_vms(argv, :reverse => true) do |machine|
+            actions = Vagrant::Openshift::Action.repo_sync_customer_diagnostics(options)
+            @env.action_runner.run actions, {:machine => machine}
+            0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/command/test_customer_diagnostics.rb
+++ b/lib/vagrant-openshift/command/test_customer_diagnostics.rb
@@ -1,0 +1,69 @@
+#--
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+require_relative "../action"
+
+module Vagrant
+  module Openshift
+    module Commands
+      class TestCustomerDiagnostics < Vagrant.plugin(2, :command)
+        include CommandHelper
+
+        def self.synopsis
+          "run the customer diagnostics tests"
+        end
+
+        def execute
+          options = {}
+          options[:download] = false
+          options[:target] = 'test-integration'
+
+          opts = OptionParser.new do |o|
+            o.banner = "Usage: vagrant test-customer-diagnostics [machine-name]"
+            o.separator ""
+
+            o.on("", "--root", String, "Run tests as root") do |f|
+              options[:root] = true
+            end
+
+            o.on("-d","--artifacts", String, "Download logs") do |f|
+              options[:download] = true
+            end
+
+            o.on("", "--env ENV=VALUE", String, "Environment variable to execute tests with") do |f|
+              options[:envs] = [] unless options[:envs]
+              options[:envs] << f
+            end
+
+            o.on("-t", "--target MAKEFILE_TARGETS", String, "Arguments to pass to the repository Makefile") do |f|
+              options[:target] = f
+            end
+
+          end
+
+          # Parse the options
+          argv = parse_options(opts)
+          return if !argv
+
+          with_target_vms(argv, :reverse => true) do |machine|
+            actions = Vagrant::Openshift::Action.run_customer_diagnostics_tests(options)
+            @env.action_runner.run actions, {:machine => machine}
+            0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-openshift/constants.rb
+++ b/lib/vagrant-openshift/constants.rb
@@ -55,6 +55,9 @@ module Vagrant
           'origin-aggregated-logging' => aggregated_logging_repos,
           'origin-metrics' => {
             'origin-metrics' => 'https://github.com/openshift/origin-metrics.git'
+          },
+          'openshift-ansible' => {
+            'openshift-ansible' => 'https://github.com/rhcarvalho/openshift-ansible.git'
           }
         }[reponame]
       end

--- a/lib/vagrant-openshift/plugin.rb
+++ b/lib/vagrant-openshift/plugin.rb
@@ -147,6 +147,11 @@ module Vagrant
         Commands::TestOriginMetrics
       end
 
+      command "test-customer-diagnostics" do
+        require_relative "command/test_customer_diagnostics"
+        Commands::TestCustomerDiagnostics
+      end
+
       command "download-artifacts-origin" do
         require_relative "command/download_artifacts_origin"
         Commands::DownloadArtifactsOrigin
@@ -210,6 +215,11 @@ module Vagrant
       command "sync-origin-metrics" do
         require_relative "command/repo_sync_origin_metrics"
         Commands::RepoSyncOriginMetrics
+      end
+
+      command "sync-customer-diagnostics" do
+        require_relative "command/repo_sync_customer_diagnostics"
+        Commands::RepoSyncCustomerDiagnostics
       end
 
       provisioner(:openshift) do


### PR DESCRIPTION
The customer diagnostics team is prototyping a test suite written in go for
testing ansible-based tooling.  Right now we're still in the early stages so a
fork of openshift-ansible is being used.  If things go well by the end of the
sprint we expect to merge this to openshift-ansible and at that time we'd
update the urls accordingly.

The goal with these new commands is simply to enable a test and merge workflow
that matches other Origin teams.  The implementation is almost entirely similar
to the other sync and test commands that we have.