### PR TITLE
Added `openssl` as a base dependency for Origin

### DIFF
--- a/lib/vagrant-openshift/resources/install_dependencies.sh
+++ b/lib/vagrant-openshift/resources/install_dependencies.sh
@@ -36,6 +36,7 @@ yum install -y                       \
             mlocate                  \
             ntp                      \
             openldap-clients         \
+            openssl                  \
             openvswitch              \
             rubygems                 \
             screen                   \


### PR DESCRIPTION
This binary is necessary for certificate tests in Origin's
`test-cmd.sh` suite.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>