### PR TITLE
Removed `yum update` step from Origin installation

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -68,7 +68,6 @@ module Vagrant
 
       def self.install_origin(options)
         Vagrant::Action::Builder.new.tap do |b|
-          b.use YumUpdate
           b.use SetHostName
           b.use InstallOrigin
           b.use InstallOriginRhel7


### PR DESCRIPTION
Now that we require environments to have a specific version of Docker
and/or Golang installed, one that is not guaranteed to be the latest
version available, we must not do broad `yum update` actions after the
dependency installation step is complete. With a properly functioning
system, all stages of the VM images are published at regular intervals
and it is unlikely that the versions of base dependencies in these
images will lag significantly behind what is available in repositories.
We can therefore achieve the `yum update` by simply consuming newer
image stages as they become available.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>