### PR TITLE
Added an option to skip Docker volume group setup

### DIFF
--- a/lib/vagrant-openshift/action/install_docker.rb
+++ b/lib/vagrant-openshift/action/install_docker.rb
@@ -44,7 +44,12 @@ module Vagrant
           )
 
           # Configure the Docker daemon
-          sudo(@env[:machine], "SSH_USER='#{ssh_user}' #{home}/configure_docker.sh", :timeout=>60*30)
+          if @options[:skip_volume_group]
+            skip_volume_group = "SKIP_VG=true"
+          else
+            skip_volume_group = ""
+          end
+          sudo(@env[:machine], "#{skip_volume_group} SSH_USER='#{ssh_user}' #{home}/configure_docker.sh", :timeout=>60*30)
 
           @app.call(@env)
         end

--- a/lib/vagrant-openshift/command/install_docker.rb
+++ b/lib/vagrant-openshift/command/install_docker.rb
@@ -29,6 +29,7 @@ module Vagrant
           options = {}
           options[:"docker.repourls"] = []
           options[:"docker.reponames"] = []
+          options[:skip_volume_group] = false
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant install-docker [vm-name]"
@@ -48,6 +49,10 @@ module Vagrant
 
             o.on("--force", String, "Uninstall Docker to swap in the new version, even if the uninstall is unclean.") do |f|
               options[:force] = true
+            end
+
+            o.on("-s", "--skip-volume-group", "Skip creating volume groups for Docker storage.") do |f|
+              options[:skip_volume_group] = true
             end
 
           end

--- a/lib/vagrant-openshift/resources/configure_docker.sh
+++ b/lib/vagrant-openshift/resources/configure_docker.sh
@@ -12,17 +12,20 @@ sed -i "s,^OPTIONS='\\(.*\\)',OPTIONS='${ADDITIONAL_OPTIONS} \\1'," /etc/sysconf
 sed -i "s,^OPTIONS=-\\(.*\\),OPTIONS='${ADDITIONAL_OPTIONS} -\\1'," /etc/sysconfig/docker
 sed -i "s,^ADD_REGISTRY='\\(.*\\)',#ADD_REGISTRY='--add-registry=docker.io \\1'," /etc/sysconfig/docker
 
-if lvdisplay docker-vg >/dev/null 2>&1; then
-    VG="docker-vg"
-elif lvdisplay vg_vagrant >/dev/null 2>&1; then
-    VG="vg_vagrant"
-elif lvdisplay fedora >/dev/null 2>&1; then
-    VG="fedora"
-elif lvdisplay centos >/dev/null 2>&1; then
-    VG="centos"
-fi
+if [[ -z "${SKIP_VG:-}" ]]; then
+    if lvdisplay docker-vg >/dev/null 2>&1; then
+        VG="docker-vg"
+    elif lvdisplay vg_vagrant >/dev/null 2>&1; then
+        VG="vg_vagrant"
+    elif lvdisplay fedora >/dev/null 2>&1; then
+        VG="fedora"
+    elif lvdisplay centos >/dev/null 2>&1; then
+        VG="centos"
+    else
+        echo "[ERROR] Could not determine volume group to use for Docker storage!"
+        exit 1
+    fi
 
-if [[ -n "${VG}" ]]; then
     lvcreate -n docker-data -l 70%FREE /dev/${VG}
     lvcreate -n docker-metadata -l 17%FREE /dev/${VG}
     lvcreate -n openshift-xfs-vol-dir -l 100%FREE /dev/${VG}


### PR DESCRIPTION
In the generic case where a user is creating an environment using this
tool, they may or may not want to use volume groups for Docker storage.
We should allow them to choose, but keep the current behavior as the
default. When we are trying to use volume groups but cannot find the
group to use, we should also fail loudly and clearly.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>