### PR TITLE
Build dind images only if build script is present

### DIFF
--- a/lib/vagrant-openshift/action/build_origin_base_images.rb
+++ b/lib/vagrant-openshift/action/build_origin_base_images.rb
@@ -32,7 +32,9 @@ echo "Building base images..."
 set -e
 pushd /data/src/github.com/openshift/origin
   hack/build-base-images.sh
-  hack/build-dind-images.sh
+  if [[ -f "hack/build-dind-images.sh" ]]; then
+    hack/build-dind-images.sh
+  fi
 popd
 },
             { :timeout => 60*60*2, :verbose => false })


### PR DESCRIPTION
This avoids the issue of having to backport the script to branches that lack the script.  Building the images is an optimization for jobs that run all the time, so branches will still work without it so long as the build doesn't error out due a missing script.

cc: @smarterclayton 