### PR TITLE
add some basic support for jenkins repo

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -153,6 +153,18 @@ module Vagrant
         end
       end
 
+      def self.repo_sync_jenkins(options)
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use PrepareSshConfig
+          if options[:clean]
+              b.use Clean, :repo => 'jenkins'
+              b.use CloneUpstreamRepositories, :repo => 'jenkins'
+          end
+          b.use SyncLocalRepository, :repo => 'jenkins'
+          b.use CheckoutRepositories, :repo => 'jenkins'
+        end
+      end
+
       def self.repo_sync_origin_console(options)
         Vagrant::Action::Builder.new.tap do |b|
           b.use PrepareSshConfig

--- a/lib/vagrant-openshift/command/repo_sync_jenkins.rb
+++ b/lib/vagrant-openshift/command/repo_sync_jenkins.rb
@@ -18,19 +18,27 @@ require_relative "../action"
 module Vagrant
   module Openshift
     module Commands
-      class DownloadArtifactsSti < Vagrant.plugin(2, :command)
+      class RepoSyncJenkins < Vagrant.plugin(2, :command)
         include CommandHelper
 
         def self.synopsis
-          "download the sti test artifacts"
+          "syncs your local repos to the current instance"
         end
 
         def execute
           options = {}
+          options[:no_build] = false
+          options[:clean] = false
+          options[:source] = false
 
           opts = OptionParser.new do |o|
-            o.banner = "Usage: vagrant download-artifacts-sti [machine-name]"
+            o.banner = "Usage: vagrant sync-jenkins [vm-name]"
             o.separator ""
+
+            o.on("-c", "--clean", "Delete existing repo before syncing") do |f|
+              options[:clean] = f
+            end
+
           end
 
           # Parse the options
@@ -38,7 +46,7 @@ module Vagrant
           return if !argv
 
           with_target_vms(argv, :reverse => true) do |machine|
-            actions = Vagrant::Openshift::Action.download_sti_artifacts(options)
+            actions = Vagrant::Openshift::Action.repo_sync_jenkins(options)
             @env.action_runner.run actions, {:machine => machine}
             0
           end

--- a/lib/vagrant-openshift/constants.rb
+++ b/lib/vagrant-openshift/constants.rb
@@ -35,6 +35,16 @@ module Vagrant
         }
       end
 
+      def self.jenkins_repos
+        {
+          'jenkins' => 'https://github.com/openshift/jenkins.git',
+          'jenkins-plugin' => 'https://github.com/openshift/jenkins-plugin.git',
+          'jenkins-client-plugin' => 'https://github.com/openshift/jenkins-client-plugin.git',
+          'jenkins-openshift-login-plugin' => 'https://github.com/openshift/jenkins-openshift-login-plugin.git',
+          'jenkins-sync-plugin' => 'https://github.com/openshift/jenkins-sync-plugin.git'
+        }
+      end
+
       def self.console_repos
         {
           'origin-web-console' => 'https://github.com/openshift/origin-web-console.git'
@@ -51,6 +61,7 @@ module Vagrant
         {
           'origin' => openshift_repos,
           nil => openshift_repos,
+          'jenkins' => jenkins_repos,
           'origin-console' => console_repos,
           'origin-aggregated-logging' => aggregated_logging_repos,
           'origin-metrics' => {

--- a/lib/vagrant-openshift/plugin.rb
+++ b/lib/vagrant-openshift/plugin.rb
@@ -47,6 +47,11 @@ module Vagrant
         Commands::RepoSyncSti
       end
 
+      command "sync-jenkins" do
+        require_relative "command/repo_sync_jenkins"
+        Commands::RepoSyncJenkins
+      end
+
       command "build-atomic-host" do
         require_relative "command/build_atomic_host"
         Commands::BuildAtomicHost


### PR DESCRIPTION
@danmcp @stevekuznetsov @bparees fyi / ptal

This allows for some minimal build/sync/test of the openshift jenkins rhel7 image.  download artifacts seemed like a no-op for this particular scenario.

@bparees - fyi this foray, in addition to facilitating say 32 vs. 64 bit jenkins, gave me some better exposure into what we might want to do longer term for plugin testing (including client and sync in addition to pipeline and long) from ci.openshift.