### PR TITLE
Install EPEL using the `epel-release` package

### DIFF
--- a/lib/vagrant-openshift/action/create_yum_repositories.rb
+++ b/lib/vagrant-openshift/action/create_yum_repositories.rb
@@ -55,7 +55,7 @@ module Vagrant
 
           unless is_fedora
             unless env[:machine].communicate.test("rpm -q epel-release")
-              sudo(env[:machine], "yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm")
+              sudo(env[:machine], "yum install -y epel-release")
 
               #Workaround broken RHEL image which does not recover after restart.
               if "VagrantPlugins::AWS::Provider" == env[:machine].provider.class.to_s


### PR DESCRIPTION
Instead of pinning the EPEL installation to a specific RPM and version
from a download, we should install EPEL using the `epel-release` package
available in `yum`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>