### PR TITLE
mount local openshift epel mirror only during image builds, no final …

### DIFF
--- a/lib/vagrant-openshift/action/build_origin.rb
+++ b/lib/vagrant-openshift/action/build_origin.rb
@@ -28,10 +28,18 @@ module Vagrant
 
         def call(env)
           if @options[:images]
+            # Migrate the local epel repo to the host machine
+            ssh_user = @env[:machine].ssh_info[:username]
+            destination="/home/#{ssh_user}/"
+            @env[:machine].communicate.upload(File.join(__dir__,"/../resources"), destination)
+            home="#{destination}/resources"
+          
+            sudo(@env[:machine], "#{home}/install_local_epel_repos.sh")
+            
             cmd = %{
 echo "Performing origin release build with images..."
 set -e
-make release
+OS_BUILD_IMAGE_ARGS='--mount /etc/yum.repos.d/local_epel.repo:/etc/yum.repos.d/local_epel.repo' make release
 }
           else
             cmd = %{

--- a/lib/vagrant-openshift/action/install_origin_rhel7.rb
+++ b/lib/vagrant-openshift/action/install_origin_rhel7.rb
@@ -49,6 +49,9 @@ rm -rf $contextdir/repos/redhat-rhui*
 # remove google chrome repo
 rm -rf $contextdir/repos/*chrome*.repo
 
+# remove local openshift epel mirror - we will only temporarily mount this via imagebuilder during image builds
+rm -rf $contextdir/repos/local_epel.repo 
+
 # create Dockerfile
 cat <<EOF > $contextdir/Dockerfile
 FROM registry.access.redhat.com/rhel7.1:latest

--- a/lib/vagrant-openshift/resources/install_local_epel_repos.sh
+++ b/lib/vagrant-openshift/resources/install_local_epel_repos.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o errexit
+
+# on RHEL machines, if we're installing or using OSE, we will need the
+# following repositories in order to fetch OSE-specific RPMs
+
+mv "$(dirname "${BASH_SOURCE}")/local_epel.repo" /etc/yum.repos.d/

--- a/lib/vagrant-openshift/resources/local_epel.repo
+++ b/lib/vagrant-openshift/resources/local_epel.repo
@@ -1,0 +1,24 @@
+[local-epel]
+name=Extra Packages for Enterprise Linux 7 - $basearch
+baseurl=https://mirror.openshift.com/mirror/epel/7/x86_64
+#mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+# according to note from sdodson in https://github.com/openshift/origin/issues/8571, default priority is 99,
+# but to ensure our local mirror is not overriden, setitng to 1
+priority=1
+
+[local-epel-debuginfo]
+name=Extra Packages for Enterprise Linux 7 - $basearch - Debug
+baseurl=https://mirror.openshift.com/mirror/epel/7/x86_64/debug
+#mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-debug-7&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+gpgcheck=1
+# according to note from sdodson in https://github.com/openshift/origin/issues/8571, default priority is 99,
+# but to ensure our local mirror is not overriden, setitng to 1
+priority=1
+


### PR DESCRIPTION
…image output

@stevekuznetsov FYI - per our chat at your cube, here is the vagrant-openshift prototype.  Let me know how you want this reflected in the new origin-ci-tool component.

Also note, after this change, we need to change the Dockerfile's in the origin repo to install yum-plugin-priorities in a separate `RUN` step prior to installing `epel-release`, etc.