### PR TITLE
Add gpgme and libassuan to install dependencies

### DIFF
--- a/lib/vagrant-openshift/resources/install_dependencies.sh
+++ b/lib/vagrant-openshift/resources/install_dependencies.sh
@@ -4,33 +4,37 @@ set -o errexit
 
 yum install -y                       \
             augeas                   \
-            bzr                      \
-            bridge-utils             \
-            bzip2                    \
             bind                     \
+            bind-utils               \
+            bridge-utils             \
             bsdtar                   \
             btrfs-progs-devel        \
-            bind-utils               \
+            bzip2                    \
+            bzr                      \
             ctags                    \
             device-mapper-devel      \
-            ethtool                  \
             e2fsprogs                \
+            ethtool                  \
             firefox                  \
             fontconfig               \
-            git                      \
             gcc                      \
             gcc-c++                  \
+            git                      \
             glibc-static             \
             gnuplot                  \
-            httpie                   \
+            gpgme                    \
+            gpgme-devel              \
             hg                       \
+            httpie                   \
             iscsi-initiator-utils    \
-            jq                       \
             java-1.?.0-openjdk       \
+            jq                       \
             kernel-devel             \
             krb5-devel               \
-            libselinux-devel         \
+            libassuan                \
+            libassuan-devel          \
             libnetfilter_queue-devel \
+            libselinux-devel         \
             lsof                     \
             make                     \
             mlocate                  \


### PR DESCRIPTION
@stevekuznetsov this is required for https://github.com/openshift/origin/pull/13585 to pass the `godep restore` test.

Long story short... We are not going to build Origin with these libraries as CGO deps as we will have special build tag that will disable it.. However, `godep` is stupid and it will try to compile the `containers/images` which will result in compilation error and test failure...

So.. this is only needed to fix that test. After this merge, I guess I will have to kick new base_ami build.