### PR TITLE
Install `etcd` without using root privileges

### DIFF
--- a/lib/vagrant-openshift/action/install_origin.rb
+++ b/lib/vagrant-openshift/action/install_origin.rb
@@ -50,10 +50,6 @@ DELIM
 
 source /etc/profile.d/openshift.sh
 
-pushd $ORIGIN_PATH
-  hack/install-etcd.sh
-popd
-
 
 mkdir -p /openshift.local.config/master/
 touch /openshift.local.config/master/admin.kubeconfig
@@ -99,6 +95,12 @@ chmod +x /usr/bin/generate_openshift_service
 #systemctl enable openshift.service
 
 chown -R #{ssh_user}:#{ssh_user} /data
+          }, :verbose => false)
+
+          do_execute(env[:machine], %{
+pushd /data/src/github.com/openshift/origin
+  hack/install-etcd.sh
+popd
           }, :verbose => false)
 
           @app.call(env)


### PR DESCRIPTION
Nothing in the `hack/install-etcd.sh` script requires root privileges
and using them was causing other issues with unrelated scripts by
mucking up the ownership and permissions on shared directories. We just
install `etcd` without `sudo`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]