### PR TITLE
Use `origin-web-console` instead of `origin-console`

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -158,11 +158,11 @@ module Vagrant
           b.use PrepareSshConfig
           if options[:source]
             if options[:clean]
-              b.use Clean, :repo => 'origin-console'
-              b.use CloneUpstreamRepositories, :repo => 'origin-console'
+              b.use Clean, :repo => 'origin-web-console'
+              b.use CloneUpstreamRepositories, :repo => 'origin-web-console'
             end
-            b.use SyncLocalRepository, :repo => 'origin-console'
-            b.use CheckoutRepositories, :repo => 'origin-console'
+            b.use SyncLocalRepository, :repo => 'origin-web-console'
+            b.use CheckoutRepositories, :repo => 'origin-web-console'
             if options[:build]
               b.use InstallOriginAssetDependencies, :restore_assets => true
             end


### PR DESCRIPTION
The Git repository for the Origin Web Console is named
`origin-web-console`, not `origin-console`, so we should use the correct
name to identify it in our code. This is now necessary as we have
refacoted the code to remove the need for nick-names for the repos and
instead use the names of the repos themselves.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @jwforres 