### PR TITLE
Pass S2I name explicitly instead of relying on null behavior

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -135,8 +135,9 @@ test_vagrant build-origin --images
 
 test_vagrant test-origin-console -d
 
+test_vagrant origin-local-checkout --replace --repo source-to-image 
 test_vagrant clone-upstream-repos --clean --repo source-to-image
-test_vagrant checkout-repos --repo source-to-image
+test_vagrant sync-sti --clean --source
 test_vagrant build-sti --binary-only
 
 popd

--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -141,11 +141,11 @@ module Vagrant
           b.use PrepareSshConfig
           if options[:source]
             if options[:clean]
-              b.use Clean
-              b.use CloneUpstreamRepositories
+              b.use Clean, :repo => 'source-to-image'
+              b.use CloneUpstreamRepositories, :repo => 'source-to-image'
             end
-            b.use SyncLocalRepository
-            b.use CheckoutRepositories
+            b.use SyncLocalRepository, :repo => 'source-to-image'
+            b.use CheckoutRepositories, :repo => 'source-to-image'
           end
           unless options[:no_build]
             b.use(BuildSti, options)


### PR DESCRIPTION
In the past we were relying on default behavior when a null was passed
as the repository to sync when syncing source-to-image. This patch makes
that repository specification explicit.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>