### PR TITLE
Pass Origin name explicitly instead of relying on null behavior

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -123,10 +123,10 @@ module Vagrant
           if options[:source]
             if options[:clean]
               b.use Clean
-              b.use CloneUpstreamRepositories
+              b.use CloneUpstreamRepositories, :repo => 'origin'
             end
-            b.use SyncLocalRepository
-            b.use CheckoutRepositories
+            b.use SyncLocalRepository, :repo => 'origin'
+            b.use CheckoutRepositories, :repo => 'origin'
           end
           if options[:build]
             b.use(BuildOriginBaseImages, options) if options[:images]


### PR DESCRIPTION
In the past we were relying on default behavior when a null was passed
as the repository to sync when syncing the Origin repo. This patch makes
that repository specification explicit.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>