### PR TITLE
Add a flag to disable asset install on Origin install

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -77,7 +77,9 @@ module Vagrant
           b.use SetHostName
           b.use InstallOrigin
           b.use InstallOriginRhel7
-          b.use InstallOriginAssetDependencies, :restore_assets => true
+          if options[:install_assets]
+            b.use InstallOriginAssetDependencies, :restore_assets => true
+          end
         end
       end
 

--- a/lib/vagrant-openshift/command/install_origin.rb
+++ b/lib/vagrant-openshift/command/install_origin.rb
@@ -28,10 +28,15 @@ module Vagrant
         def execute
           options = {}
           options[:clean] = false
+          options[:install_assets] = true
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant install-origin [vm-name]"
             o.separator ""
+
+            o.on("-s", "--skip-assets", "Don't install the asset dependencies.") do |f|
+              options[:install_assets] = false
+            end
           end
 
           # Parse the options


### PR DESCRIPTION
Many jobs need to install Origin but do not need to install the Origin
Web Console asset dependencies as they do not run the Web Console tests
and only consume the Web Console via the vendored bindata.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @jwforres PTAL