### PR TITLE
DRY out repo sync logic, add Jenkins sync

### DIFF
--- a/lib/vagrant-openshift/action.rb
+++ b/lib/vagrant-openshift/action.rb
@@ -121,18 +121,12 @@ module Vagrant
 
       def self.repo_sync_origin(options)
         Vagrant::Action::Builder.new.tap do |b|
-          b.use PrepareSshConfig
-          if options[:source]
-            if options[:clean]
-              b.use Clean
-              b.use CloneUpstreamRepositories, :repo => 'origin'
-            end
-            b.use SyncLocalRepository, :repo => 'origin'
-            b.use CheckoutRepositories, :repo => 'origin'
-          end
+          self.repo_sync_generic(b, options)
           if options[:build]
-            b.use(BuildOriginBaseImages, options) if options[:images]
-            b.use(BuildOrigin, options)
+            if options[:images]
+              b.use BuildOriginBaseImages, options
+            end
+            b.use BuildOrigin, options
             b.use RunSystemctl, {:action => "try-restart", :service => "openshift"}
           end
         end
@@ -140,16 +134,8 @@ module Vagrant
 
       def self.repo_sync_sti(options)
         Vagrant::Action::Builder.new.tap do |b|
-          b.use PrepareSshConfig
-          if options[:source]
-            if options[:clean]
-              b.use Clean, :repo => 'source-to-image'
-              b.use CloneUpstreamRepositories, :repo => 'source-to-image'
-            end
-            b.use SyncLocalRepository, :repo => 'source-to-image'
-            b.use CheckoutRepositories, :repo => 'source-to-image'
-          end
-          unless options[:no_build]
+          self.repo_sync_generic(b, options)
+          if options[:build]
             b.use(BuildSti, options)
           end
         end
@@ -157,66 +143,28 @@ module Vagrant
 
       def self.repo_sync_origin_console(options)
         Vagrant::Action::Builder.new.tap do |b|
-          b.use PrepareSshConfig
-          if options[:source]
-            if options[:clean]
-              b.use Clean, :repo => 'origin-web-console'
-              b.use CloneUpstreamRepositories, :repo => 'origin-web-console'
-            end
-            b.use SyncLocalRepository, :repo => 'origin-web-console'
-            b.use CheckoutRepositories, :repo => 'origin-web-console'
-            if options[:build]
-              b.use InstallOriginAssetDependencies, :restore_assets => true
-            end
+          self.repo_sync_generic(b, options)
+          if options[:build]
+            b.use InstallOriginAssetDependencies, :restore_assets => true
           end
         end
       end
 
-      def self.repo_sync_origin_aggregated_logging(options)
+      def self.repo_sync(options)
         Vagrant::Action::Builder.new.tap do |b|
-          b.use PrepareSshConfig
-          if options[:source]
-            if options[:clean]
-              b.use(Clean, options)
-              b.use(CloneUpstreamRepositories, options)
-            end
-            b.use(SyncLocalRepository, options)
-            b.use(CheckoutRepositories, options)
-          end
-          # no build support currently
-          # if options[:build]
-          #   b.use(BuildOriginBaseImages, options) if options[:images]
-          #   b.use(BuildOrigin, options)
-          #   b.use RunSystemctl, {:action => "try-restart", :service => "openshift"}
-          # end
+          self.repo_sync_generic(b, options)
         end
       end
 
-      def self.repo_sync_origin_metrics(options)
-        Vagrant::Action::Builder.new.tap do |b|
-          b.use PrepareSshConfig
-          if options[:source]
-            if options[:clean]
-              b.use Clean, options
-              b.use CloneUpstreamRepositories, options
-            end
-            b.use SyncLocalRepository, options
-            b.use CheckoutRepositories, options
+      def self.repo_sync_generic(b, options)
+        b.use PrepareSshConfig
+        if options[:source]
+          if options[:clean]
+            b.use Clean, options
+            b.use CloneUpstreamRepositories, options
           end
-        end
-      end
-
-      def self.repo_sync_customer_diagnostics(options)
-        Vagrant::Action::Builder.new.tap do |b|
-          b.use PrepareSshConfig
-          if options[:source]
-            if options[:clean]
-              b.use Clean, options
-              b.use CloneUpstreamRepositories, options
-            end
-            b.use SyncLocalRepository, options
-            b.use CheckoutRepositories, options
-          end
+          b.use SyncLocalRepository, options
+          b.use CheckoutRepositories, options
         end
       end
 

--- a/lib/vagrant-openshift/command/repo_sync_customer_diagnostics.rb
+++ b/lib/vagrant-openshift/command/repo_sync_customer_diagnostics.rb
@@ -60,7 +60,7 @@ module Vagrant
           return if !argv
 
           with_target_vms(argv, :reverse => true) do |machine|
-            actions = Vagrant::Openshift::Action.repo_sync_customer_diagnostics(options)
+            actions = Vagrant::Openshift::Action.repo_sync(options)
             @env.action_runner.run actions, {:machine => machine}
             0
           end

--- a/lib/vagrant-openshift/command/repo_sync_jenkins.rb
+++ b/lib/vagrant-openshift/command/repo_sync_jenkins.rb
@@ -18,7 +18,7 @@ require_relative "../action"
 module Vagrant
   module Openshift
     module Commands
-      class RepoSyncOriginAggregatedLogging < Vagrant.plugin(2, :command)
+      class RepoSyncJenkins < Vagrant.plugin(2, :command)
         include CommandHelper
 
         def self.synopsis
@@ -31,10 +31,10 @@ module Vagrant
           options[:build] = true
           options[:clean] = false
           options[:source] = false
-          options[:repo] = 'origin-aggregated-logging'
+          options[:repo] = 'jenkins'
 
           opts = OptionParser.new do |o|
-            o.banner = "Usage: vagrant sync-origin-aggregated-logging [vm-name]"
+            o.banner = "Usage: vagrant sync-jenkins [vm-name]"
             o.separator ""
 
             o.on("-s", "--source", "Sync the source (not required if using synced folders)") do |f|

--- a/lib/vagrant-openshift/command/repo_sync_origin.rb
+++ b/lib/vagrant-openshift/command/repo_sync_origin.rb
@@ -31,6 +31,7 @@ module Vagrant
           options[:build] = true
           options[:clean] = false
           options[:source] = false
+          options[:repo] = 'origin'
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant sync-origin [vm-name]"

--- a/lib/vagrant-openshift/command/repo_sync_origin_console.rb
+++ b/lib/vagrant-openshift/command/repo_sync_origin_console.rb
@@ -31,6 +31,7 @@ module Vagrant
           options[:build] = true
           options[:clean] = false
           options[:source] = false
+          options[:repo] = 'origin-web-console'
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant sync-origin-console [vm-name]"

--- a/lib/vagrant-openshift/command/repo_sync_origin_metrics.rb
+++ b/lib/vagrant-openshift/command/repo_sync_origin_metrics.rb
@@ -60,7 +60,7 @@ module Vagrant
           return if !argv
 
           with_target_vms(argv, :reverse => true) do |machine|
-            actions = Vagrant::Openshift::Action.repo_sync_origin_metrics(options)
+            actions = Vagrant::Openshift::Action.repo_sync(options)
             @env.action_runner.run actions, {:machine => machine}
             0
           end

--- a/lib/vagrant-openshift/command/repo_sync_sti.rb
+++ b/lib/vagrant-openshift/command/repo_sync_sti.rb
@@ -27,9 +27,10 @@ module Vagrant
 
         def execute
           options = {}
-          options[:no_build] = false
+          options[:build] = true
           options[:clean] = false
           options[:source] = false
+          options[:repo] = 'source-to-image'
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant sync-sti [vm-name]"
@@ -44,7 +45,7 @@ module Vagrant
             end
 
             o.on("--dont-install", "Don't build and install updated source") do |f|
-              options[:no_build] = true
+              options[:build] = false
             end
 
           end

--- a/lib/vagrant-openshift/plugin.rb
+++ b/lib/vagrant-openshift/plugin.rb
@@ -223,17 +223,17 @@ module Vagrant
       end
 
       command "sync-origin-aggregated-logging" do
-        require_relative "command/repo_sync_origin_aggregated_logging"
+        require_relative "command/repo_sync"
         Commands::RepoSyncOriginAggregatedLogging
       end
 
       command "sync-origin-metrics" do
-        require_relative "command/repo_sync_origin_metrics"
+        require_relative "command/repo_sync"
         Commands::RepoSyncOriginMetrics
       end
 
       command "sync-customer-diagnostics" do
-        require_relative "command/repo_sync_customer_diagnostics"
+        require_relative "command/repo_sync"
         Commands::RepoSyncCustomerDiagnostics
       end
 


### PR DESCRIPTION
Removing a lot of the duplication between the different repo sync
commands allows us to add one for the Jenkins repo with minimal effort.
It would be nice to have a `vagrant sync-repo [REPO]` command but this
would be a breaking change for the CLI, so we can continue with the
named commands per repo instead.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@dobbymoodge @bparees PTAL

/cc @gabemontero not entirely sure how Jenkins was getting synced  over in the past, but we can use `vagrant sync-jenkins` after this patch lands